### PR TITLE
Move consecutive COPY commands to avoid Docker bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
-LABEL name="HLF Operator" \
-      vendor="Kung Fu Software <dviejo@kungfusoftware.es>" \
-      maintainer="Kung Fu Software <dviejo@kungfusoftware.es>" \
-      version="v1.1.0" \
-      release="v1.1.0"
 
 RUN \
     microdnf update --nodocs && \
@@ -13,6 +8,12 @@ RUN \
 COPY CREDITS /licenses/CREDITS
 COPY LICENSE /licenses/LICENSE
 COPY LICENSE /licenses/LICENSE
+LABEL name="HLF Operator" \
+      vendor="Kung Fu Software <dviejo@kungfusoftware.es>" \
+      maintainer="Kung Fu Software <dviejo@kungfusoftware.es>" \
+      version="v1.1.0" \
+      release="v1.1.0"
+
 COPY charts /charts
 
 COPY hlf-operator /hlf-operator


### PR DESCRIPTION
There seems to be a bug in docker affecting Github Actions to build docker images with 3 consecutive COPY/ADD commands.

moby/moby#37965 (comment)
moby/moby#38866

Moving 2 copy commands before the label and keeping the docker
entrypoint addition afterwards circumvents this issue.