### PR TITLE
Fix/bad templates indentation

### DIFF
--- a/controllers/networkconfig/networkconfig_controller.go
+++ b/controllers/networkconfig/networkconfig_controller.go
@@ -57,7 +57,7 @@ organizations:
  	  {{- end }}
 {{- end }}
 {{- if not $org.OrderingServices }}
-	orderers: []
+    orderers: []
 {{- else }}
     orderers:
       {{- range $ordService := $org.OrderingServices }}

--- a/controllers/networkconfig/networkconfig_controller.go
+++ b/controllers/networkconfig/networkconfig_controller.go
@@ -49,7 +49,7 @@ organizations:
     cryptoPath: /tmp/cryptopath
     users: {}
 {{- if not $org.Peers }}
-	peers: []
+    peers: []
 {{- else }}
     peers:
       {{- range $peer := $org.Peers }}
@@ -117,7 +117,7 @@ certificateAuthorities: []
 {{- else }}
 certificateAuthorities:
 {{- range $ca := .CertAuths }}
-  
+
   {{ $ca.Name }}:
 {{if $.Internal }}
     url: https://{{ $ca.PrivateURL }}
@@ -131,7 +131,7 @@ certificateAuthorities:
 {{ end }}
     caName: ca
     tlsCACerts:
-      pem: 
+      pem:
        - |
 {{ $ca.Status.TlsCert | indent 12 }}
 

--- a/kubectl-hlf/cmd/inspect/inspect.go
+++ b/kubectl-hlf/cmd/inspect/inspect.go
@@ -70,7 +70,7 @@ organizations:
  	  {{- end }}
 {{- end }}
 {{- if not $org.OrderingServices }}
-	orderers: []
+    orderers: []
 {{- else }}
     orderers:
       {{- range $ordService := $org.OrderingServices }}

--- a/kubectl-hlf/cmd/inspect/inspect.go
+++ b/kubectl-hlf/cmd/inspect/inspect.go
@@ -62,7 +62,7 @@ organizations:
     cryptoPath: /tmp/cryptopath
     users: {}
 {{- if not $org.Peers }}
-	peers: []
+    peers: []
 {{- else }}
     peers:
       {{- range $peer := $org.Peers }}
@@ -130,7 +130,7 @@ certificateAuthorities: []
 {{- else }}
 certificateAuthorities:
 {{- range $ca := .CertAuths }}
-  
+
   {{ $ca.Name }}:
 {{if $.Internal }}
     url: https://{{ $ca.PrivateURL }}
@@ -144,7 +144,7 @@ certificateAuthorities:
 {{ end }}
     caName: ca
     tlsCACerts:
-      pem: 
+      pem:
        - |
 {{ $ca.Status.TlsCert | indent 12 }}
 


### PR DESCRIPTION
Fixed bad "peers" and "orderers" indentations in:
- controllers/networkconfig/networkconfig_controller.go
- kubectl-hlf/cmd/inspect/inspect.go