### PR TITLE
Using service type as ClusterIP when istio is used.

### DIFF
--- a/kubectl-hlf/cmd/ca/create.go
+++ b/kubectl-hlf/cmd/ca/create.go
@@ -70,12 +70,14 @@ func (c *createCmd) run(args []string) error {
 		Hosts:          []string{},
 		IngressGateway: ingressGateway,
 	}
+	serviceType := corev1.ServiceTypeNodePort
 	if len(c.caOpts.Hosts) > 0 {
 		istio = &v1alpha1.FabricIstio{
 			Port:           ingressPort,
 			Hosts:          c.caOpts.Hosts,
 			IngressGateway: ingressGateway,
 		}
+		serviceType = corev1.ServiceTypeClusterIP
 	}
 
 	hosts := []string{
@@ -102,7 +104,7 @@ func (c *createCmd) run(args []string) error {
 			},
 			Hosts: hosts,
 			Service: v1alpha1.FabricCASpecService{
-				ServiceType: "NodePort",
+				ServiceType: serviceType,
 			},
 			Image:        c.caOpts.Image,
 			Version:      c.caOpts.Version,

--- a/kubectl-hlf/cmd/ordnode/create.go
+++ b/kubectl-hlf/cmd/ordnode/create.go
@@ -102,10 +102,11 @@ func (c *createCmd) run(args []string) error {
 		}
 	}
 	caHost := k8sIP
-	if c.ordererOpts.CAHost != "" {
-		caHost = c.ordererOpts.CAHost
-	}
 	caPort := certAuth.Status.NodePort
+	if len(certAuth.Spec.Istio.Hosts) > 0 {
+		caHost = certAuth.Spec.Istio.Hosts[0]
+		caPort = certAuth.Spec.Istio.Port
+	}
 	if c.ordererOpts.CAPort != 0 {
 		caPort = c.ordererOpts.CAPort
 	}

--- a/kubectl-hlf/cmd/ordnode/create.go
+++ b/kubectl-hlf/cmd/ordnode/create.go
@@ -103,9 +103,11 @@ func (c *createCmd) run(args []string) error {
 	}
 	caHost := k8sIP
 	caPort := certAuth.Status.NodePort
+	serviceType := corev1.ServiceTypeNodePort
 	if len(certAuth.Spec.Istio.Hosts) > 0 {
 		caHost = certAuth.Spec.Istio.Hosts[0]
 		caPort = certAuth.Spec.Istio.Port
+		serviceType = corev1.ServiceTypeClusterIP
 	}
 	if c.ordererOpts.CAPort != 0 {
 		caPort = c.ordererOpts.CAPort
@@ -151,7 +153,7 @@ func (c *createCmd) run(args []string) error {
 				AccessMode:   "ReadWriteOnce",
 			},
 			Service: v1alpha1.OrdererNodeService{
-				Type: "NodePort",
+				Type: serviceType,
 			},
 			Secret: &v1alpha1.Secret{
 				Enrollment: v1alpha1.Enrollment{

--- a/kubectl-hlf/cmd/peer/create.go
+++ b/kubectl-hlf/cmd/peer/create.go
@@ -123,6 +123,9 @@ func (c *createCmd) run() error {
 	}
 	csrHosts = append(csrHosts, c.peerOpts.Name)
 	csrHosts = append(csrHosts, fmt.Sprintf("%s.%s", c.peerOpts.Name, c.peerOpts.NS))
+	if len(c.peerOpts.Hosts) > 0 {
+		csrHosts = append(csrHosts, c.peerOpts.Hosts...)
+	}
 	var externalBuilders []v1alpha1.ExternalBuilder
 	if c.peerOpts.ExternalChaincodeServiceBuilder {
 		externalBuilders = append(externalBuilders, v1alpha1.ExternalBuilder{

--- a/kubectl-hlf/cmd/peer/create.go
+++ b/kubectl-hlf/cmd/peer/create.go
@@ -170,10 +170,16 @@ func (c *createCmd) run() error {
 		couchDB.Tag = c.peerOpts.CouchDBTag
 	}
 	caHost := k8sIP
+	caPort := certAuth.Status.NodePort
+	serviceType := corev1.ServiceTypeNodePort
+	if len(certAuth.Spec.Istio.Hosts) > 0 {
+		caHost = certAuth.Spec.Istio.Hosts[0]
+		caPort = certAuth.Spec.Istio.Port
+		serviceType = corev1.ServiceTypeClusterIP
+	}
 	if c.peerOpts.CAHost != "" {
 		caHost = c.peerOpts.CAHost
 	}
-	caPort := certAuth.Status.NodePort
 	if c.peerOpts.CAPort != 0 {
 		caPort = c.peerOpts.CAPort
 	}
@@ -254,7 +260,7 @@ func (c *createCmd) run() error {
 				},
 			},
 			Service: v1alpha1.PeerService{
-				Type: "NodePort",
+				Type: serviceType,
 			},
 			StateDb: v1alpha1.StateDB(c.peerOpts.StateDB),
 			Storage: v1alpha1.FabricPeerStorage{


### PR DESCRIPTION
1. Updated Kubernetes service type NodePort to ClusterIP when `istio`is used.
2. Updates made for `CA` and `Peer` resource