### PR TITLE
Fix kubectl-hlf inspect command when empty peer array

### DIFF
--- a/kubectl-hlf/cmd/inspect/inspect.go
+++ b/kubectl-hlf/cmd/inspect/inspect.go
@@ -102,7 +102,7 @@ orderers:
 {{- end }}
 
 {{- if not .Peers }}
-peers: []
+peers: {}
 {{- else }}
 peers:
   {{- range $peer := .Peers }}


### PR DESCRIPTION
Found this bug while playing around with the operator, if organization has no peers it results in an error:

`network configuration load failed: failed to parse 'peers' config item to endpointConfigurationEntity.Peers type: '' expected a map, got 'slice'`