### PR TITLE
added support for auto cert renewal flags in hlf-operator helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bin
 *.swp
 *.swo
 *~
+*.DS_Store
 
 crypto-config
 keystore

--- a/chart/hlf-operator/Chart.yaml
+++ b/chart/hlf-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 1.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricchaincodes.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricchaincodes.yaml
@@ -6,16 +6,16 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: fabriccas.hlf.kungfusoftware.es
+  name: fabricchaincodes.hlf.kungfusoftware.es
 spec:
   group: hlf.kungfusoftware.es
   names:
-    kind: FabricCA
-    listKind: FabricCAList
-    plural: fabriccas
+    kind: FabricChaincode
+    listKind: FabricChaincodeList
+    plural: fabricchaincodes
     shortNames:
-    - ca
-    singular: ca
+    - fabricchaincode
+    singular: fabricchaincode
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -28,7 +28,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: FabricCA is the Schema for the hlfs API
+        description: FabricChaincode is the Schema for the hlfs API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -43,7 +43,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FabricCASpec defines the desired state of FabricCA
+            description: FabricChaincodeSpec defines the desired state of FabricChaincode
             properties:
               affinity:
                 description: Affinity is a group of affinity scheduling rules.
@@ -863,390 +863,75 @@ spec:
                         type: array
                     type: object
                 type: object
-              ca:
+              args:
+                description: Arguments to the entrypoint. The container image's CMD
+                  is used if this is not provided.
+                items:
+                  type: string
+                type: array
+              command:
+                description: Entrypoint array. Not executed within a shell. The container
+                  image's ENTRYPOINT is used if this is not provided.
+                items:
+                  type: string
+                type: array
+              credentials:
+                nullable: true
                 properties:
-                  affiliations:
-                    items:
-                      properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          type: string
-                      required:
-                      - departments
-                      - name
-                      type: object
-                    nullable: true
-                    type: array
-                  bccsp:
+                  cahost:
+                    type: string
+                  caname:
+                    type: string
+                  caport:
+                    type: integer
+                  catls:
                     properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
+                      cacert:
                         type: string
                     required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
+                    - cacert
                     type: object
                   csr:
                     properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
                       cn:
-                        default: ca
                         type: string
                       hosts:
-                        default:
-                        - localhost
                         items:
                           type: string
                         type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
                     type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
+                  enrollid:
                     type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
+                  enrollsecret:
+                    type: string
+                  external:
                     nullable: true
                     properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
-                        type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
-                        type: object
-                    required:
-                    - default
-                    - profiles
-                    type: object
-                  subject:
-                    properties:
-                      C:
-                        default: US
+                      certificateKey:
                         type: string
-                      L:
-                        default: Raleigh
+                      privateKeyKey:
                         type: string
-                      O:
-                        default: Hyperledger
+                      rootCertificateKey:
                         type: string
-                      OU:
-                        default: Fabric
+                      secretName:
                         type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
+                      secretNamespace:
                         type: string
                     required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
+                    - certificateKey
+                    - privateKeyKey
+                    - rootCertificateKey
+                    - secretName
+                    - secretNamespace
                     type: object
                 required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
+                - cahost
+                - caname
+                - caport
+                - catls
+                - enrollid
+                - enrollsecret
                 type: object
-              clrSizeLimit:
-                default: 512000
-                type: integer
-              cors:
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  origins:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - enabled
-                - origins
-                type: object
-              db:
-                properties:
-                  datasource:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - datasource
-                - type
-                type: object
-              debug:
-                default: false
-                type: boolean
               env:
                 items:
                   description: EnvVar represents an environment variable present in
@@ -1352,33 +1037,12 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              gatewayApi:
-                nullable: true
-                properties:
-                  gatewayName:
-                    type: string
-                  gatewayNamespace:
-                    type: string
-                  hosts:
-                    items:
-                      type: string
-                    nullable: true
-                    type: array
-                  port:
-                    nullable: true
-                    type: integer
-                required:
-                - gatewayName
-                - gatewayNamespace
-                type: object
-              hosts:
-                description: Hosts for the Fabric CA
-                items:
-                  type: string
-                minItems: 1
-                type: array
               image:
-                minLength: 1
+                type: string
+              imagePullPolicy:
+                default: IfNotPresent
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               imagePullSecrets:
                 items:
@@ -1392,136 +1056,14 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              istio:
-                nullable: true
-                properties:
-                  hosts:
-                    items:
-                      type: string
-                    nullable: true
-                    type: array
-                  ingressGateway:
-                    type: string
-                  port:
-                    nullable: true
-                    type: integer
-                required:
-                - ingressGateway
-                type: object
-              metrics:
-                properties:
-                  provider:
-                    default: disabled
-                    type: string
-                  statsd:
-                    properties:
-                      address:
-                        type: string
-                      network:
-                        default: udp
-                        enum:
-                        - udp
-                        - tcp
-                        type: string
-                      prefix:
-                        default: ""
-                        type: string
-                      writeInterval:
-                        default: 10s
-                        type: string
-                    required:
-                    - network
-                    type: object
-                required:
-                - provider
-                type: object
-              nodeSelector:
-                description: A node selector represents the union of the results of
-                  one or more label queries over a set of nodes; that is, it represents
-                  the OR of the selectors represented by the node selector terms.
-                nullable: true
-                properties:
-                  nodeSelectorTerms:
-                    description: Required. A list of node selector terms. The terms
-                      are ORed.
-                    items:
-                      description: A null or empty node selector term matches no objects.
-                        The requirements of them are ANDed. The TopologySelectorTerm
-                        type implements a subset of the NodeSelectorTerm.
-                      properties:
-                        matchExpressions:
-                          description: A list of node selector requirements by node's
-                            labels.
-                          items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
-                                type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
-                                type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
-                          type: array
-                        matchFields:
-                          description: A list of node selector requirements by node's
-                            fields.
-                          items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
-                                type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
-                                type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
-                          type: array
-                      type: object
-                    type: array
-                required:
-                - nodeSelectorTerms
-                type: object
+              packageId:
+                minLength: 1
+                type: string
+              replicas:
+                type: integer
               resources:
                 description: ResourceRequirements describes the compute resource requirements.
+                nullable: true
                 properties:
                   limits:
                     additionalProperties:
@@ -1545,443 +1087,6 @@ spec:
                       it defaults to Limits if that is explicitly specified, otherwise
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
-                type: object
-              rootCA:
-                properties:
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                required:
-                - subject
-                type: object
-              service:
-                properties:
-                  type:
-                    description: Service Type string describes ingress methods for
-                      a service
-                    type: string
-                required:
-                - type
-                type: object
-              serviceMonitor:
-                nullable: true
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  interval:
-                    default: 10s
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  sampleLimit:
-                    default: 0
-                    type: integer
-                  scrapeTimeout:
-                    default: 10s
-                    type: string
-                required:
-                - enabled
-                - interval
-                - sampleLimit
-                - scrapeTimeout
-                type: object
-              storage:
-                properties:
-                  accessMode:
-                    default: ReadWriteOnce
-                    type: string
-                  size:
-                    default: 5Gi
-                    type: string
-                  storageClass:
-                    default: ""
-                    type: string
-                required:
-                - accessMode
-                - size
-                type: object
-              tlsCA:
-                properties:
-                  affiliations:
-                    items:
-                      properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          type: string
-                      required:
-                      - departments
-                      - name
-                      type: object
-                    nullable: true
-                    type: array
-                  bccsp:
-                    properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
-                    type: object
-                  csr:
-                    properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
-                      cn:
-                        default: ca
-                        type: string
-                      hosts:
-                        default:
-                        - localhost
-                        items:
-                          type: string
-                        type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
-                    type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
-                    type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
-                    nullable: true
-                    properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
-                        type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
-                        type: object
-                    required:
-                    - default
-                    - profiles
-                    type: object
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
-                    type: object
-                required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
                 type: object
               tolerations:
                 items:
@@ -2023,31 +1128,15 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              version:
-                minLength: 1
-                type: string
             required:
-            - ca
-            - clrSizeLimit
-            - cors
-            - db
-            - debug
-            - hosts
             - image
-            - metrics
-            - resources
-            - rootCA
-            - service
-            - storage
-            - tlsCA
-            - version
+            - imagePullPolicy
+            - packageId
+            - replicas
             type: object
           status:
-            description: FabricCAStatus defines the observed state of FabricCA
+            description: FabricChaincodeStatus defines the observed state of FabricChaincode
             properties:
-              ca_cert:
-                description: Root certificate for Sign certificates generated by FabricCA
-                type: string
               conditions:
                 description: Conditions is a set of Condition instances.
                 items:
@@ -2090,24 +1179,13 @@ spec:
                 type: array
               message:
                 type: string
-              nodePort:
-                type: integer
               status:
-                description: Status of the FabricCA
-                type: string
-              tls_cert:
-                description: TLS Certificate to connect to the FabricCA
-                type: string
-              tlsca_cert:
-                description: Root certificate for TLS certificates generated by FabricCA
+                description: Status of the FabricChaincode
                 type: string
             required:
-            - ca_cert
             - conditions
             - message
             - status
-            - tls_cert
-            - tlsca_cert
             type: object
         type: object
     served: true

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricexplorers.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricexplorers.yaml
@@ -1,0 +1,140 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: fabricexplorers.hlf.kungfusoftware.es
+spec:
+  group: hlf.kungfusoftware.es
+  names:
+    kind: FabricExplorer
+    listKind: FabricExplorerList
+    plural: fabricexplorers
+    shortNames:
+    - explorer
+    singular: explorer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FabricExplorer is the Schema for the hlfs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FabricExplorerSpec defines the desired state of FabricExplorer
+            properties:
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+            required:
+            - resources
+            type: object
+          status:
+            description: FabricExplorerStatus defines the observed state of FabricExplorer
+            properties:
+              conditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              status:
+                description: Status of the FabricCA
+                type: string
+            required:
+            - conditions
+            - message
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricfollowerchannels.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricfollowerchannels.yaml
@@ -1,0 +1,208 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: fabricfollowerchannels.hlf.kungfusoftware.es
+spec:
+  group: hlf.kungfusoftware.es
+  names:
+    kind: FabricFollowerChannel
+    listKind: FabricFollowerChannelList
+    plural: fabricfollowerchannels
+    shortNames:
+    - fabricfollowerchannel
+    singular: fabricfollowerchannel
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FabricFollowerChannel is the Schema for the hlfs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FabricFollowerChannelSpec defines the desired state of FabricFollowerChannel
+            properties:
+              anchorPeers:
+                description: Anchor peers defined for the current organization
+                items:
+                  properties:
+                    host:
+                      description: Host of the anchor peer
+                      type: string
+                    port:
+                      description: Port of the anchor peer
+                      type: integer
+                  required:
+                  - host
+                  - port
+                  type: object
+                type: array
+              externalPeersToJoin:
+                description: Peers to join the channel
+                items:
+                  properties:
+                    tlsCACert:
+                      description: FabricPeer TLS CA certificate of the peer
+                      type: string
+                    url:
+                      description: FabricPeer URL of the peer
+                      type: string
+                  required:
+                  - tlsCACert
+                  - url
+                  type: object
+                type: array
+              hlfIdentity:
+                description: Identity to use to interact with the peers and the orderers
+                properties:
+                  secretKey:
+                    description: Key inside the secret that holds the private key
+                      and certificate to interact with the network
+                    type: string
+                  secretName:
+                    description: Secret name
+                    type: string
+                  secretNamespace:
+                    default: default
+                    description: Secret namespace
+                    type: string
+                required:
+                - secretKey
+                - secretName
+                - secretNamespace
+                type: object
+              mspId:
+                description: MSP ID of the organization to join the channel
+                type: string
+              name:
+                description: Name of the channel
+                type: string
+              orderers:
+                description: Orderers to fetch the configuration block from
+                items:
+                  properties:
+                    certificate:
+                      description: TLS Certificate of the orderer node
+                      type: string
+                    url:
+                      description: 'URL of the orderer, e.g.: "grpcs://xxxxx:443"'
+                      type: string
+                  required:
+                  - certificate
+                  - url
+                  type: object
+                type: array
+              peersToJoin:
+                description: Peers to join the channel
+                items:
+                  properties:
+                    name:
+                      description: FabricPeer Name of the peer inside the kubernetes
+                        cluster
+                      type: string
+                    namespace:
+                      description: FabricPeer Namespace of the peer inside the kubernetes
+                        cluster
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                type: array
+            required:
+            - anchorPeers
+            - externalPeersToJoin
+            - hlfIdentity
+            - mspId
+            - name
+            - orderers
+            - peersToJoin
+            type: object
+          status:
+            description: FabricFollowerChannelStatus defines the observed state of
+              FabricFollowerChannel
+            properties:
+              conditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              status:
+                description: Status of the FabricCA
+                type: string
+            required:
+            - conditions
+            - message
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricidentities.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricidentities.yaml
@@ -1,0 +1,173 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: fabricidentities.hlf.kungfusoftware.es
+spec:
+  group: hlf.kungfusoftware.es
+  names:
+    kind: FabricIdentity
+    listKind: FabricIdentityList
+    plural: fabricidentities
+    shortNames:
+    - fabricidentity
+    singular: fabricidentity
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FabricIdentity is the Schema for the hlfs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FabricIdentitySpec defines the desired state of FabricIdentity
+            properties:
+              cahost:
+                minLength: 1
+                type: string
+              caname:
+                minLength: 1
+                type: string
+              caport:
+                type: integer
+              catls:
+                properties:
+                  cacert:
+                    type: string
+                required:
+                - cacert
+                type: object
+              enrollid:
+                minLength: 1
+                type: string
+              enrollsecret:
+                minLength: 1
+                type: string
+              mspid:
+                minLength: 1
+                type: string
+              register:
+                nullable: true
+                properties:
+                  affiliation:
+                    minLength: 1
+                    type: string
+                  attrs:
+                    items:
+                      type: string
+                    type: array
+                  enrollid:
+                    minLength: 1
+                    type: string
+                  enrollsecret:
+                    minLength: 1
+                    type: string
+                  maxenrollments:
+                    type: integer
+                  type:
+                    minLength: 1
+                    type: string
+                required:
+                - affiliation
+                - attrs
+                - enrollid
+                - enrollsecret
+                - maxenrollments
+                - type
+                type: object
+            required:
+            - cahost
+            - caname
+            - caport
+            - catls
+            - enrollid
+            - enrollsecret
+            - mspid
+            type: object
+          status:
+            description: FabricMainChannelStatus defines the observed state of FabricMainChannel
+            properties:
+              conditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              status:
+                description: Status of the FabricCA
+                type: string
+            required:
+            - conditions
+            - message
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricmainchannels.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricmainchannels.yaml
@@ -1,0 +1,509 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: fabricmainchannels.hlf.kungfusoftware.es
+spec:
+  group: hlf.kungfusoftware.es
+  names:
+    kind: FabricMainChannel
+    listKind: FabricMainChannelList
+    plural: fabricmainchannels
+    shortNames:
+    - fabricmainchannel
+    singular: fabricmainchannel
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FabricMainChannel is the Schema for the hlfs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FabricMainChannelSpec defines the desired state of FabricMainChannel
+            properties:
+              adminOrdererOrganizations:
+                description: Organizations that manage the `orderer` configuration
+                  of the channel
+                items:
+                  properties:
+                    mspID:
+                      description: MSP ID of the organization
+                      type: string
+                  required:
+                  - mspID
+                  type: object
+                type: array
+              adminPeerOrganizations:
+                description: Organizations that manage the `application` configuration
+                  of the channel
+                items:
+                  properties:
+                    mspID:
+                      description: MSP ID of the organization
+                      type: string
+                  required:
+                  - mspID
+                  type: object
+                type: array
+              channelConfig:
+                description: Configuration about the channel
+                nullable: true
+                properties:
+                  application:
+                    description: Application configuration of the channel
+                    nullable: true
+                    properties:
+                      acls:
+                        additionalProperties:
+                          type: string
+                        description: ACLs of the application channel configuration
+                        nullable: true
+                        type: object
+                      capabilities:
+                        default:
+                        - V2_0
+                        description: Capabilities of the application channel configuration
+                        items:
+                          type: string
+                        type: array
+                      policies:
+                        additionalProperties:
+                          properties:
+                            modPolicy:
+                              type: string
+                            rule:
+                              description: Rule of policy
+                              type: string
+                            type:
+                              description: Type of policy, can only be `ImplicitMeta`
+                                or `Signature`.
+                              type: string
+                          required:
+                          - modPolicy
+                          - rule
+                          - type
+                          type: object
+                        description: Policies of the application channel configuration
+                        nullable: true
+                        type: object
+                    required:
+                    - capabilities
+                    type: object
+                  capabilities:
+                    default:
+                    - V2_0
+                    description: Capabilities for the channel
+                    items:
+                      type: string
+                    type: array
+                  orderer:
+                    description: Orderer configuration of the channel
+                    nullable: true
+                    properties:
+                      batchSize:
+                        nullable: true
+                        properties:
+                          absoluteMaxBytes:
+                            default: 1048576
+                            description: The absolute maximum size of a block, including
+                              all metadata.
+                            type: integer
+                          maxMessageCount:
+                            default: 100
+                            description: The number of transactions that can fit in
+                              a block.
+                            type: integer
+                          preferredMaxBytes:
+                            default: 524288
+                            description: The preferred maximum size of a block, including
+                              all metadata.
+                            type: integer
+                        required:
+                        - absoluteMaxBytes
+                        - maxMessageCount
+                        - preferredMaxBytes
+                        type: object
+                      batchTimeout:
+                        default: 2s
+                        description: Interval of the ordering service to create a
+                          block and send to the peers
+                        type: string
+                      capabilities:
+                        default:
+                        - V2_0
+                        description: Capabilities of the channel
+                        items:
+                          type: string
+                        type: array
+                      etcdRaft:
+                        nullable: true
+                        properties:
+                          options:
+                            nullable: true
+                            properties:
+                              electionTick:
+                                default: 10
+                                format: int32
+                                type: integer
+                              heartbeatTick:
+                                default: 1
+                                description: HeartbeatTick is the number of ticks
+                                  that must pass between heartbeats
+                                format: int32
+                                type: integer
+                              maxInflightBlocks:
+                                default: 5
+                                description: MaxInflightBlocks is the maximum number
+                                  of in-flight blocks that may be sent to followers
+                                  at any given time.
+                                format: int32
+                                type: integer
+                              snapshotIntervalSize:
+                                default: 16777216
+                                description: Maximum size of each raft snapshot file.
+                                format: int32
+                                type: integer
+                              tickInterval:
+                                default: 500ms
+                                type: string
+                            required:
+                            - electionTick
+                            - heartbeatTick
+                            - maxInflightBlocks
+                            - snapshotIntervalSize
+                            - tickInterval
+                            type: object
+                        type: object
+                      ordererType:
+                        default: etcdraft
+                        description: OrdererType of the consensus, default "etcdraft"
+                        type: string
+                      policies:
+                        additionalProperties:
+                          properties:
+                            modPolicy:
+                              type: string
+                            rule:
+                              description: Rule of policy
+                              type: string
+                            type:
+                              description: Type of policy, can only be `ImplicitMeta`
+                                or `Signature`.
+                              type: string
+                          required:
+                          - modPolicy
+                          - rule
+                          - type
+                          type: object
+                        description: Policies of the orderer section of the channel
+                        nullable: true
+                        type: object
+                      state:
+                        default: STATE_NORMAL
+                        description: State about the channel, can only be `STATE_NORMAL`
+                          or `STATE_MAINTENANCE`.
+                        type: string
+                    required:
+                    - batchTimeout
+                    - capabilities
+                    - ordererType
+                    - state
+                    type: object
+                  policies:
+                    additionalProperties:
+                      properties:
+                        modPolicy:
+                          type: string
+                        rule:
+                          description: Rule of policy
+                          type: string
+                        type:
+                          description: Type of policy, can only be `ImplicitMeta`
+                            or `Signature`.
+                          type: string
+                      required:
+                      - modPolicy
+                      - rule
+                      - type
+                      type: object
+                    description: Policies for the channel
+                    nullable: true
+                    type: object
+                required:
+                - capabilities
+                type: object
+              externalOrdererOrganizations:
+                description: Orderer organizations that are external to the Kubernetes
+                  cluster
+                items:
+                  properties:
+                    mspID:
+                      description: MSP ID of the organization
+                      type: string
+                    ordererEndpoints:
+                      description: Orderer endpoints for the organization in the channel
+                        configuration
+                      items:
+                        type: string
+                      type: array
+                    signRootCert:
+                      description: Root certificate authority for signing
+                      type: string
+                    tlsRootCert:
+                      description: TLS Root certificate authority of the orderer organization
+                      type: string
+                  required:
+                  - mspID
+                  - ordererEndpoints
+                  - signRootCert
+                  - tlsRootCert
+                  type: object
+                type: array
+              externalPeerOrganizations:
+                description: External peer organizations that are inside the kubernetes
+                  cluster
+                items:
+                  properties:
+                    mspID:
+                      description: MSP ID of the organization
+                      type: string
+                    signRootCert:
+                      description: Root certificate authority for signing
+                      type: string
+                    tlsRootCert:
+                      description: TLS Root certificate authority of the orderer organization
+                      type: string
+                  required:
+                  - mspID
+                  - signRootCert
+                  - tlsRootCert
+                  type: object
+                type: array
+              identities:
+                additionalProperties:
+                  properties:
+                    secretKey:
+                      description: Key inside the secret that holds the private key
+                        and certificate to interact with the network
+                      type: string
+                    secretName:
+                      description: Secret name
+                      type: string
+                    secretNamespace:
+                      default: default
+                      description: Secret namespace
+                      type: string
+                  required:
+                  - secretKey
+                  - secretName
+                  - secretNamespace
+                  type: object
+                description: HLF Identities to be used to create and manage the channel
+                type: object
+              name:
+                description: Name of the channel
+                type: string
+              ordererOrganizations:
+                description: External orderer organizations that are inside the kubernetes
+                  cluster
+                items:
+                  properties:
+                    caName:
+                      description: FabricCA Name of the organization
+                      type: string
+                    caNamespace:
+                      description: FabricCA Namespace of the organization
+                      type: string
+                    externalOrderersToJoin:
+                      description: External orderers to be added to the channel
+                      items:
+                        properties:
+                          host:
+                            description: Admin host of the orderer node
+                            type: string
+                          port:
+                            description: Admin port of the orderer node
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      type: array
+                    mspID:
+                      description: MSP ID of the organization
+                      type: string
+                    ordererEndpoints:
+                      description: Orderer endpoints for the organization in the channel
+                        configuration
+                      items:
+                        type: string
+                      type: array
+                    orderersToJoin:
+                      description: Orderer nodes within the kubernetes cluster to
+                        be added to the channel
+                      items:
+                        properties:
+                          name:
+                            description: Name of the orderer node
+                            type: string
+                          namespace:
+                            description: Kubernetes namespace of the orderer node
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      type: array
+                    signCACert:
+                      description: Root certificate authority for signing
+                      type: string
+                    tlsCACert:
+                      description: TLS Root certificate authority of the orderer organization
+                      type: string
+                  required:
+                  - externalOrderersToJoin
+                  - mspID
+                  - ordererEndpoints
+                  - orderersToJoin
+                  type: object
+                type: array
+              orderers:
+                description: Consenters are the orderer nodes that are part of the
+                  channel consensus
+                items:
+                  properties:
+                    host:
+                      description: Orderer host of the consenter
+                      type: string
+                    port:
+                      description: Orderer port of the consenter
+                      type: integer
+                    tlsCert:
+                      description: TLS Certificate of the orderer node
+                      type: string
+                  required:
+                  - host
+                  - port
+                  - tlsCert
+                  type: object
+                type: array
+              peerOrganizations:
+                description: Peer organizations that are external to the Kubernetes
+                  cluster
+                items:
+                  properties:
+                    caName:
+                      description: FabricCA Name of the organization
+                      type: string
+                    caNamespace:
+                      description: FabricCA Namespace of the organization
+                      type: string
+                    mspID:
+                      description: MSP ID of the organization
+                      type: string
+                  required:
+                  - caName
+                  - caNamespace
+                  - mspID
+                  type: object
+                type: array
+            required:
+            - adminOrdererOrganizations
+            - adminPeerOrganizations
+            - channelConfig
+            - externalOrdererOrganizations
+            - externalPeerOrganizations
+            - identities
+            - name
+            - ordererOrganizations
+            - orderers
+            - peerOrganizations
+            type: object
+          status:
+            description: FabricMainChannelStatus defines the observed state of FabricMainChannel
+            properties:
+              conditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              status:
+                description: Status of the FabricCA
+                type: string
+            required:
+            - conditions
+            - message
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricnetworkconfigs.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricnetworkconfigs.yaml
@@ -1,0 +1,151 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: fabricnetworkconfigs.hlf.kungfusoftware.es
+spec:
+  group: hlf.kungfusoftware.es
+  names:
+    kind: FabricNetworkConfig
+    listKind: FabricNetworkConfigList
+    plural: fabricnetworkconfigs
+    shortNames:
+    - networkconfig
+    singular: networkconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FabricNetworkConfig is the Schema for the hlfs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FabricNetworkConfigSpec defines the desired state of FabricNetworkConfig
+            properties:
+              channels:
+                items:
+                  type: string
+                type: array
+              identities:
+                description: HLF Identities to be included in the network config
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                type: array
+              internal:
+                type: boolean
+              namespaces:
+                items:
+                  type: string
+                type: array
+              organization:
+                type: string
+              organizations:
+                items:
+                  type: string
+                type: array
+              secretName:
+                type: string
+            required:
+            - channels
+            - identities
+            - internal
+            - namespaces
+            - organization
+            - organizations
+            - secretName
+            type: object
+          status:
+            description: FabricNetworkConfigStatus defines the observed state of FabricNetworkConfig
+            properties:
+              conditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              status:
+                description: Status of the FabricNetworkConfig
+                type: string
+            required:
+            - conditions
+            - message
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricoperationsconsoles.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricoperationsconsoles.yaml
@@ -6,16 +6,16 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: fabriccas.hlf.kungfusoftware.es
+  name: fabricoperationsconsoles.hlf.kungfusoftware.es
 spec:
   group: hlf.kungfusoftware.es
   names:
-    kind: FabricCA
-    listKind: FabricCAList
-    plural: fabriccas
+    kind: FabricOperationsConsole
+    listKind: FabricOperationsConsoleList
+    plural: fabricoperationsconsoles
     shortNames:
-    - ca
-    singular: ca
+    - fabricoperationsconsoles
+    singular: fabricoperationsconsoles
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -28,7 +28,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: FabricCA is the Schema for the hlfs API
+        description: FabricOperationsConsole is the Schema for the hlfs API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -43,7 +43,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: FabricCASpec defines the desired state of FabricCA
+            description: FabricOperationsConsoleSpec defines the desired state of
+              FabricOperationsConsole
             properties:
               affinity:
                 description: Affinity is a group of affinity scheduling rules.
@@ -863,390 +864,1004 @@ spec:
                         type: array
                     type: object
                 type: object
-              ca:
+              auth:
                 properties:
-                  affiliations:
+                  password:
+                    type: string
+                  scheme:
+                    default: couchdb
+                    type: string
+                  username:
+                    type: string
+                required:
+                - password
+                - scheme
+                - username
+                type: object
+              config:
+                nullable: true
+                type: string
+              couchDB:
+                description: FabricOperationsConsoleSpec defines the desired state
+                  of FabricOperationsConsole
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    nullable: true
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  image:
+                    default: couchdb
+                    type: string
+                  imagePullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  imagePullSecrets:
                     items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
                       properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
                         name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                      required:
-                      - departments
-                      - name
                       type: object
                     nullable: true
                     type: array
-                  bccsp:
-                    properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
-                    type: object
-                  csr:
-                    properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
-                      cn:
-                        default: ca
-                        type: string
-                      hosts:
-                        default:
-                        - localhost
-                        items:
-                          type: string
-                        type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
-                    type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
+                  password:
                     type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
                     nullable: true
                     properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
-                    required:
-                    - default
-                    - profiles
                     type: object
-                  subject:
+                  storage:
                     properties:
-                      C:
-                        default: US
+                      accessMode:
+                        default: ReadWriteOnce
                         type: string
-                      L:
-                        default: Raleigh
+                      size:
+                        default: 5Gi
                         type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
+                      storageClass:
+                        default: ""
                         type: string
                     required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
+                    - accessMode
+                    - size
                     type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
-                    type: object
-                required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
-                type: object
-              clrSizeLimit:
-                default: 512000
-                type: integer
-              cors:
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  origins:
+                  tag:
+                    default: 3.1.1
+                    type: string
+                  tolerations:
                     items:
-                      type: string
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    nullable: true
                     type: array
-                required:
-                - enabled
-                - origins
-                type: object
-              db:
-                properties:
-                  datasource:
-                    type: string
-                  type:
+                  username:
                     type: string
                 required:
-                - datasource
-                - type
+                - image
+                - imagePullPolicy
+                - password
+                - storage
+                - tag
+                - username
                 type: object
-              debug:
-                default: false
-                type: boolean
               env:
                 items:
                   description: EnvVar represents an environment variable present in
@@ -1352,33 +1967,15 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              gatewayApi:
-                nullable: true
-                properties:
-                  gatewayName:
-                    type: string
-                  gatewayNamespace:
-                    type: string
-                  hosts:
-                    items:
-                      type: string
-                    nullable: true
-                    type: array
-                  port:
-                    nullable: true
-                    type: integer
-                required:
-                - gatewayName
-                - gatewayNamespace
-                type: object
-              hosts:
-                description: Hosts for the Fabric CA
-                items:
-                  type: string
-                minItems: 1
-                type: array
+              hostUrl:
+                type: string
               image:
-                minLength: 1
+                default: ghcr.io/hyperledger-labs/fabric-console
+                type: string
+              imagePullPolicy:
+                default: IfNotPresent
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               imagePullSecrets:
                 items:
@@ -1392,136 +1989,80 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              istio:
-                nullable: true
+              ingress:
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  className:
+                    type: string
+                  enabled:
+                    default: true
+                    type: boolean
                   hosts:
                     items:
-                      type: string
-                    nullable: true
-                    type: array
-                  ingressGateway:
-                    type: string
-                  port:
-                    nullable: true
-                    type: integer
-                required:
-                - ingressGateway
-                type: object
-              metrics:
-                properties:
-                  provider:
-                    default: disabled
-                    type: string
-                  statsd:
-                    properties:
-                      address:
-                        type: string
-                      network:
-                        default: udp
-                        enum:
-                        - udp
-                        - tcp
-                        type: string
-                      prefix:
-                        default: ""
-                        type: string
-                      writeInterval:
-                        default: 10s
-                        type: string
-                    required:
-                    - network
-                    type: object
-                required:
-                - provider
-                type: object
-              nodeSelector:
-                description: A node selector represents the union of the results of
-                  one or more label queries over a set of nodes; that is, it represents
-                  the OR of the selectors represented by the node selector terms.
-                nullable: true
-                properties:
-                  nodeSelectorTerms:
-                    description: Required. A list of node selector terms. The terms
-                      are ORed.
-                    items:
-                      description: A null or empty node selector term matches no objects.
-                        The requirements of them are ANDed. The TopologySelectorTerm
-                        type implements a subset of the NodeSelectorTerm.
                       properties:
-                        matchExpressions:
-                          description: A list of node selector requirements by node's
-                            labels.
+                        host:
+                          type: string
+                        paths:
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
                             properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
+                              path:
+                                default: /
                                 type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
+                              pathType:
+                                default: Prefix
                                 type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
                             required:
-                            - key
-                            - operator
+                            - path
+                            - pathType
                             type: object
                           type: array
-                        matchFields:
-                          description: A list of node selector requirements by node's
-                            fields.
+                      required:
+                      - host
+                      - paths
+                      type: object
+                    type: array
+                  tls:
+                    items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an Ingress.
+                      properties:
+                        hosts:
+                          description: Hosts are a list of hosts included in the TLS
+                            certificate. The values in this list must match the name/s
+                            used in the tlsSecret. Defaults to the wildcard host setting
+                            for the loadbalancer controller fulfilling this Ingress,
+                            if left unspecified.
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
-                                type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
-                                type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
+                            type: string
                           type: array
+                        secretName:
+                          description: SecretName is the name of the secret used to
+                            terminate TLS traffic on port 443. Field is left optional
+                            to allow TLS routing based on SNI hostname alone. If the
+                            SNI host in a listener conflicts with the "Host" header
+                            field used by an IngressRule, the SNI host is used for
+                            termination and value of the Host header is used for routing.
+                          type: string
                       type: object
                     type: array
                 required:
-                - nodeSelectorTerms
+                - annotations
+                - className
+                - enabled
+                - hosts
+                - tls
                 type: object
+              port:
+                default: 3000
+                type: integer
+              replicas:
+                type: integer
               resources:
                 description: ResourceRequirements describes the compute resource requirements.
+                nullable: true
                 properties:
                   limits:
                     additionalProperties:
@@ -1546,443 +2087,9 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-              rootCA:
-                properties:
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                required:
-                - subject
-                type: object
-              service:
-                properties:
-                  type:
-                    description: Service Type string describes ingress methods for
-                      a service
-                    type: string
-                required:
-                - type
-                type: object
-              serviceMonitor:
-                nullable: true
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  interval:
-                    default: 10s
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  sampleLimit:
-                    default: 0
-                    type: integer
-                  scrapeTimeout:
-                    default: 10s
-                    type: string
-                required:
-                - enabled
-                - interval
-                - sampleLimit
-                - scrapeTimeout
-                type: object
-              storage:
-                properties:
-                  accessMode:
-                    default: ReadWriteOnce
-                    type: string
-                  size:
-                    default: 5Gi
-                    type: string
-                  storageClass:
-                    default: ""
-                    type: string
-                required:
-                - accessMode
-                - size
-                type: object
-              tlsCA:
-                properties:
-                  affiliations:
-                    items:
-                      properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          type: string
-                      required:
-                      - departments
-                      - name
-                      type: object
-                    nullable: true
-                    type: array
-                  bccsp:
-                    properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
-                    type: object
-                  csr:
-                    properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
-                      cn:
-                        default: ca
-                        type: string
-                      hosts:
-                        default:
-                        - localhost
-                        items:
-                          type: string
-                        type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
-                    type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
-                    type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
-                    nullable: true
-                    properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
-                        type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
-                        type: object
-                    required:
-                    - default
-                    - profiles
-                    type: object
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
-                    type: object
-                required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
-                type: object
+              tag:
+                default: latest
+                type: string
               tolerations:
                 items:
                   description: The pod this Toleration is attached to tolerates any
@@ -2023,31 +2130,21 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              version:
-                minLength: 1
-                type: string
             required:
-            - ca
-            - clrSizeLimit
-            - cors
-            - db
-            - debug
-            - hosts
+            - auth
+            - couchDB
+            - hostUrl
             - image
-            - metrics
-            - resources
-            - rootCA
-            - service
-            - storage
-            - tlsCA
-            - version
+            - imagePullPolicy
+            - ingress
+            - port
+            - replicas
+            - tag
             type: object
           status:
-            description: FabricCAStatus defines the observed state of FabricCA
+            description: FabricOperationsConsoleStatus defines the observed state
+              of FabricOperationsConsole
             properties:
-              ca_cert:
-                description: Root certificate for Sign certificates generated by FabricCA
-                type: string
               conditions:
                 description: Conditions is a set of Condition instances.
                 items:
@@ -2090,24 +2187,13 @@ spec:
                 type: array
               message:
                 type: string
-              nodePort:
-                type: integer
               status:
                 description: Status of the FabricCA
                 type: string
-              tls_cert:
-                description: TLS Certificate to connect to the FabricCA
-                type: string
-              tlsca_cert:
-                description: Root certificate for TLS certificates generated by FabricCA
-                type: string
             required:
-            - ca_cert
             - conditions
             - message
             - status
-            - tls_cert
-            - tlsca_cert
             type: object
         type: object
     served: true

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricoperatorapis.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricoperatorapis.yaml
@@ -6,16 +6,16 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: fabriccas.hlf.kungfusoftware.es
+  name: fabricoperatorapis.hlf.kungfusoftware.es
 spec:
   group: hlf.kungfusoftware.es
   names:
-    kind: FabricCA
-    listKind: FabricCAList
-    plural: fabriccas
+    kind: FabricOperatorAPI
+    listKind: FabricOperatorAPIList
+    plural: fabricoperatorapis
     shortNames:
-    - ca
-    singular: ca
+    - fabricoperatorapi
+    singular: fabricoperatorapi
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -28,7 +28,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: FabricCA is the Schema for the hlfs API
+        description: FabricOperatorAPI is the Schema for the hlfs API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -43,7 +43,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FabricCASpec defines the desired state of FabricCA
+            description: FabricOperatorAPISpec defines the desired state of FabricOperatorAPI
             properties:
               affinity:
                 description: Affinity is a group of affinity scheduling rules.
@@ -863,390 +863,29 @@ spec:
                         type: array
                     type: object
                 type: object
-              ca:
+              auth:
+                nullable: true
                 properties:
-                  affiliations:
-                    items:
-                      properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          type: string
-                      required:
-                      - departments
-                      - name
-                      type: object
-                    nullable: true
-                    type: array
-                  bccsp:
-                    properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
-                    type: object
-                  csr:
-                    properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
-                      cn:
-                        default: ca
-                        type: string
-                      hosts:
-                        default:
-                        - localhost
-                        items:
-                          type: string
-                        type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
-                    type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
+                  oidcAuthority:
+                    default: ""
                     type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
-                    nullable: true
-                    properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
-                        type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
-                        type: object
-                    required:
-                    - default
-                    - profiles
-                    type: object
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
-                    type: object
-                required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
-                type: object
-              clrSizeLimit:
-                default: 512000
-                type: integer
-              cors:
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  origins:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - enabled
-                - origins
-                type: object
-              db:
-                properties:
-                  datasource:
+                  oidcClientId:
+                    default: ""
                     type: string
-                  type:
+                  oidcIssuer:
+                    type: string
+                  oidcJWKS:
+                    type: string
+                  oidcScope:
+                    default: ""
                     type: string
                 required:
-                - datasource
-                - type
+                - oidcAuthority
+                - oidcClientId
+                - oidcIssuer
+                - oidcJWKS
+                - oidcScope
                 type: object
-              debug:
-                default: false
-                type: boolean
               env:
                 items:
                   description: EnvVar represents an environment variable present in
@@ -1352,33 +991,33 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              gatewayApi:
-                nullable: true
+              hlfConfig:
                 properties:
-                  gatewayName:
+                  mspID:
                     type: string
-                  gatewayNamespace:
+                  networkConfig:
+                    properties:
+                      key:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - key
+                    - secretName
+                    type: object
+                  user:
                     type: string
-                  hosts:
-                    items:
-                      type: string
-                    nullable: true
-                    type: array
-                  port:
-                    nullable: true
-                    type: integer
                 required:
-                - gatewayName
-                - gatewayNamespace
+                - mspID
+                - networkConfig
+                - user
                 type: object
-              hosts:
-                description: Hosts for the Fabric CA
-                items:
-                  type: string
-                minItems: 1
-                type: array
               image:
-                minLength: 1
+                type: string
+              imagePullPolicy:
+                default: IfNotPresent
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               imagePullSecrets:
                 items:
@@ -1392,8 +1031,73 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              ingress:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  className:
+                    type: string
+                  enabled:
+                    default: true
+                    type: boolean
+                  hosts:
+                    items:
+                      properties:
+                        host:
+                          type: string
+                        paths:
+                          items:
+                            properties:
+                              path:
+                                default: /
+                                type: string
+                              pathType:
+                                default: Prefix
+                                type: string
+                            required:
+                            - path
+                            - pathType
+                            type: object
+                          type: array
+                      required:
+                      - host
+                      - paths
+                      type: object
+                    type: array
+                  tls:
+                    items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an Ingress.
+                      properties:
+                        hosts:
+                          description: Hosts are a list of hosts included in the TLS
+                            certificate. The values in this list must match the name/s
+                            used in the tlsSecret. Defaults to the wildcard host setting
+                            for the loadbalancer controller fulfilling this Ingress,
+                            if left unspecified.
+                          items:
+                            type: string
+                          type: array
+                        secretName:
+                          description: SecretName is the name of the secret used to
+                            terminate TLS traffic on port 443. Field is left optional
+                            to allow TLS routing based on SNI hostname alone. If the
+                            SNI host in a listener conflicts with the "Host" header
+                            field used by an IngressRule, the SNI host is used for
+                            termination and value of the Host header is used for routing.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - annotations
+                - className
+                - enabled
+                - hosts
+                - tls
+                type: object
               istio:
-                nullable: true
                 properties:
                   hosts:
                     items:
@@ -1408,120 +1112,18 @@ spec:
                 required:
                 - ingressGateway
                 type: object
-              metrics:
-                properties:
-                  provider:
-                    default: disabled
-                    type: string
-                  statsd:
-                    properties:
-                      address:
-                        type: string
-                      network:
-                        default: udp
-                        enum:
-                        - udp
-                        - tcp
-                        type: string
-                      prefix:
-                        default: ""
-                        type: string
-                      writeInterval:
-                        default: 10s
-                        type: string
-                    required:
-                    - network
-                    type: object
-                required:
-                - provider
+              logoUrl:
+                default: ""
+                type: string
+              podLabels:
+                additionalProperties:
+                  type: string
                 type: object
-              nodeSelector:
-                description: A node selector represents the union of the results of
-                  one or more label queries over a set of nodes; that is, it represents
-                  the OR of the selectors represented by the node selector terms.
-                nullable: true
-                properties:
-                  nodeSelectorTerms:
-                    description: Required. A list of node selector terms. The terms
-                      are ORed.
-                    items:
-                      description: A null or empty node selector term matches no objects.
-                        The requirements of them are ANDed. The TopologySelectorTerm
-                        type implements a subset of the NodeSelectorTerm.
-                      properties:
-                        matchExpressions:
-                          description: A list of node selector requirements by node's
-                            labels.
-                          items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
-                                type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
-                                type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
-                          type: array
-                        matchFields:
-                          description: A list of node selector requirements by node's
-                            fields.
-                          items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
-                                type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
-                                type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
-                          type: array
-                      type: object
-                    type: array
-                required:
-                - nodeSelectorTerms
-                type: object
+              replicas:
+                type: integer
               resources:
                 description: ResourceRequirements describes the compute resource requirements.
+                nullable: true
                 properties:
                   limits:
                     additionalProperties:
@@ -1546,443 +1148,8 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-              rootCA:
-                properties:
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                required:
-                - subject
-                type: object
-              service:
-                properties:
-                  type:
-                    description: Service Type string describes ingress methods for
-                      a service
-                    type: string
-                required:
-                - type
-                type: object
-              serviceMonitor:
-                nullable: true
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  interval:
-                    default: 10s
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  sampleLimit:
-                    default: 0
-                    type: integer
-                  scrapeTimeout:
-                    default: 10s
-                    type: string
-                required:
-                - enabled
-                - interval
-                - sampleLimit
-                - scrapeTimeout
-                type: object
-              storage:
-                properties:
-                  accessMode:
-                    default: ReadWriteOnce
-                    type: string
-                  size:
-                    default: 5Gi
-                    type: string
-                  storageClass:
-                    default: ""
-                    type: string
-                required:
-                - accessMode
-                - size
-                type: object
-              tlsCA:
-                properties:
-                  affiliations:
-                    items:
-                      properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          type: string
-                      required:
-                      - departments
-                      - name
-                      type: object
-                    nullable: true
-                    type: array
-                  bccsp:
-                    properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
-                    type: object
-                  csr:
-                    properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
-                      cn:
-                        default: ca
-                        type: string
-                      hosts:
-                        default:
-                        - localhost
-                        items:
-                          type: string
-                        type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
-                    type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
-                    type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
-                    nullable: true
-                    properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
-                        type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
-                        type: object
-                    required:
-                    - default
-                    - profiles
-                    type: object
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
-                    type: object
-                required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
-                type: object
+              tag:
+                type: string
               tolerations:
                 items:
                   description: The pod this Toleration is attached to tolerates any
@@ -2023,31 +1190,20 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              version:
-                minLength: 1
-                type: string
             required:
-            - ca
-            - clrSizeLimit
-            - cors
-            - db
-            - debug
-            - hosts
+            - hlfConfig
             - image
-            - metrics
-            - resources
-            - rootCA
-            - service
-            - storage
-            - tlsCA
-            - version
+            - imagePullPolicy
+            - ingress
+            - istio
+            - logoUrl
+            - podLabels
+            - replicas
+            - tag
             type: object
           status:
-            description: FabricCAStatus defines the observed state of FabricCA
+            description: FabricOperatorAPIStatus defines the observed state of FabricOperatorAPI
             properties:
-              ca_cert:
-                description: Root certificate for Sign certificates generated by FabricCA
-                type: string
               conditions:
                 description: Conditions is a set of Condition instances.
                 items:
@@ -2090,24 +1246,13 @@ spec:
                 type: array
               message:
                 type: string
-              nodePort:
-                type: integer
               status:
                 description: Status of the FabricCA
                 type: string
-              tls_cert:
-                description: TLS Certificate to connect to the FabricCA
-                type: string
-              tlsca_cert:
-                description: Root certificate for TLS certificates generated by FabricCA
-                type: string
             required:
-            - ca_cert
             - conditions
             - message
             - status
-            - tls_cert
-            - tlsca_cert
             type: object
         type: object
     served: true

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricoperatoruis.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricoperatoruis.yaml
@@ -6,16 +6,16 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: fabriccas.hlf.kungfusoftware.es
+  name: fabricoperatoruis.hlf.kungfusoftware.es
 spec:
   group: hlf.kungfusoftware.es
   names:
-    kind: FabricCA
-    listKind: FabricCAList
-    plural: fabriccas
+    kind: FabricOperatorUI
+    listKind: FabricOperatorUIList
+    plural: fabricoperatoruis
     shortNames:
-    - ca
-    singular: ca
+    - fabricoperatorui
+    singular: fabricoperatorui
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -28,7 +28,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: FabricCA is the Schema for the hlfs API
+        description: FabricOperatorUI is the Schema for the hlfs API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -43,7 +43,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FabricCASpec defines the desired state of FabricCA
+            description: FabricOperatorUISpec defines the desired state of FabricOperatorUI
             properties:
               affinity:
                 description: Affinity is a group of affinity scheduling rules.
@@ -863,390 +863,22 @@ spec:
                         type: array
                     type: object
                 type: object
-              ca:
+              apiUrl:
+                type: string
+              auth:
+                nullable: true
                 properties:
-                  affiliations:
-                    items:
-                      properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          type: string
-                      required:
-                      - departments
-                      - name
-                      type: object
-                    nullable: true
-                    type: array
-                  bccsp:
-                    properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
-                    type: object
-                  csr:
-                    properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
-                      cn:
-                        default: ca
-                        type: string
-                      hosts:
-                        default:
-                        - localhost
-                        items:
-                          type: string
-                        type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
-                    type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
+                  oidcAuthority:
                     type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
-                    nullable: true
-                    properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
-                        type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
-                        type: object
-                    required:
-                    - default
-                    - profiles
-                    type: object
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
-                    type: object
-                required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
-                type: object
-              clrSizeLimit:
-                default: 512000
-                type: integer
-              cors:
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  origins:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - enabled
-                - origins
-                type: object
-              db:
-                properties:
-                  datasource:
+                  oidcClientId:
                     type: string
-                  type:
+                  oidcScope:
                     type: string
                 required:
-                - datasource
-                - type
+                - oidcAuthority
+                - oidcClientId
+                - oidcScope
                 type: object
-              debug:
-                default: false
-                type: boolean
               env:
                 items:
                   description: EnvVar represents an environment variable present in
@@ -1352,33 +984,12 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              gatewayApi:
-                nullable: true
-                properties:
-                  gatewayName:
-                    type: string
-                  gatewayNamespace:
-                    type: string
-                  hosts:
-                    items:
-                      type: string
-                    nullable: true
-                    type: array
-                  port:
-                    nullable: true
-                    type: integer
-                required:
-                - gatewayName
-                - gatewayNamespace
-                type: object
-              hosts:
-                description: Hosts for the Fabric CA
-                items:
-                  type: string
-                minItems: 1
-                type: array
               image:
-                minLength: 1
+                type: string
+              imagePullPolicy:
+                default: IfNotPresent
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               imagePullSecrets:
                 items:
@@ -1392,136 +1003,80 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              istio:
-                nullable: true
+              ingress:
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  className:
+                    type: string
+                  enabled:
+                    default: true
+                    type: boolean
                   hosts:
                     items:
-                      type: string
-                    nullable: true
-                    type: array
-                  ingressGateway:
-                    type: string
-                  port:
-                    nullable: true
-                    type: integer
-                required:
-                - ingressGateway
-                type: object
-              metrics:
-                properties:
-                  provider:
-                    default: disabled
-                    type: string
-                  statsd:
-                    properties:
-                      address:
-                        type: string
-                      network:
-                        default: udp
-                        enum:
-                        - udp
-                        - tcp
-                        type: string
-                      prefix:
-                        default: ""
-                        type: string
-                      writeInterval:
-                        default: 10s
-                        type: string
-                    required:
-                    - network
-                    type: object
-                required:
-                - provider
-                type: object
-              nodeSelector:
-                description: A node selector represents the union of the results of
-                  one or more label queries over a set of nodes; that is, it represents
-                  the OR of the selectors represented by the node selector terms.
-                nullable: true
-                properties:
-                  nodeSelectorTerms:
-                    description: Required. A list of node selector terms. The terms
-                      are ORed.
-                    items:
-                      description: A null or empty node selector term matches no objects.
-                        The requirements of them are ANDed. The TopologySelectorTerm
-                        type implements a subset of the NodeSelectorTerm.
                       properties:
-                        matchExpressions:
-                          description: A list of node selector requirements by node's
-                            labels.
+                        host:
+                          type: string
+                        paths:
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
                             properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
+                              path:
+                                default: /
                                 type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
+                              pathType:
+                                default: Prefix
                                 type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
                             required:
-                            - key
-                            - operator
+                            - path
+                            - pathType
                             type: object
                           type: array
-                        matchFields:
-                          description: A list of node selector requirements by node's
-                            fields.
+                      required:
+                      - host
+                      - paths
+                      type: object
+                    type: array
+                  tls:
+                    items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an Ingress.
+                      properties:
+                        hosts:
+                          description: Hosts are a list of hosts included in the TLS
+                            certificate. The values in this list must match the name/s
+                            used in the tlsSecret. Defaults to the wildcard host setting
+                            for the loadbalancer controller fulfilling this Ingress,
+                            if left unspecified.
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: The label key that the selector applies
-                                  to.
-                                type: string
-                              operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
-                                type: string
-                              values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
+                            type: string
                           type: array
+                        secretName:
+                          description: SecretName is the name of the secret used to
+                            terminate TLS traffic on port 443. Field is left optional
+                            to allow TLS routing based on SNI hostname alone. If the
+                            SNI host in a listener conflicts with the "Host" header
+                            field used by an IngressRule, the SNI host is used for
+                            termination and value of the Host header is used for routing.
+                          type: string
                       type: object
                     type: array
                 required:
-                - nodeSelectorTerms
+                - annotations
+                - className
+                - enabled
+                - hosts
+                - tls
                 type: object
+              logoUrl:
+                default: ""
+                type: string
+              replicas:
+                type: integer
               resources:
                 description: ResourceRequirements describes the compute resource requirements.
+                nullable: true
                 properties:
                   limits:
                     additionalProperties:
@@ -1546,443 +1101,8 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-              rootCA:
-                properties:
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                required:
-                - subject
-                type: object
-              service:
-                properties:
-                  type:
-                    description: Service Type string describes ingress methods for
-                      a service
-                    type: string
-                required:
-                - type
-                type: object
-              serviceMonitor:
-                nullable: true
-                properties:
-                  enabled:
-                    default: false
-                    type: boolean
-                  interval:
-                    default: 10s
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  sampleLimit:
-                    default: 0
-                    type: integer
-                  scrapeTimeout:
-                    default: 10s
-                    type: string
-                required:
-                - enabled
-                - interval
-                - sampleLimit
-                - scrapeTimeout
-                type: object
-              storage:
-                properties:
-                  accessMode:
-                    default: ReadWriteOnce
-                    type: string
-                  size:
-                    default: 5Gi
-                    type: string
-                  storageClass:
-                    default: ""
-                    type: string
-                required:
-                - accessMode
-                - size
-                type: object
-              tlsCA:
-                properties:
-                  affiliations:
-                    items:
-                      properties:
-                        departments:
-                          items:
-                            type: string
-                          type: array
-                        name:
-                          type: string
-                      required:
-                      - departments
-                      - name
-                      type: object
-                    nullable: true
-                    type: array
-                  bccsp:
-                    properties:
-                      default:
-                        default: SW
-                        type: string
-                      sw:
-                        properties:
-                          hash:
-                            default: SHA2
-                            type: string
-                          security:
-                            default: "256"
-                            type: string
-                        required:
-                        - hash
-                        - security
-                        type: object
-                    required:
-                    - default
-                    - sw
-                    type: object
-                  ca:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      chain:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - chain
-                    - key
-                    type: object
-                  cfg:
-                    properties:
-                      affiliations:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                      identities:
-                        properties:
-                          allowRemove:
-                            default: true
-                            type: boolean
-                        required:
-                        - allowRemove
-                        type: object
-                    required:
-                    - affiliations
-                    - identities
-                    type: object
-                  crl:
-                    properties:
-                      expiry:
-                        default: 24h
-                        type: string
-                    required:
-                    - expiry
-                    type: object
-                  csr:
-                    properties:
-                      ca:
-                        properties:
-                          expiry:
-                            default: 131400h
-                            type: string
-                          pathLength:
-                            default: 0
-                            type: integer
-                        required:
-                        - expiry
-                        - pathLength
-                        type: object
-                      cn:
-                        default: ca
-                        type: string
-                      hosts:
-                        default:
-                        - localhost
-                        items:
-                          type: string
-                        type: array
-                      names:
-                        items:
-                          properties:
-                            C:
-                              default: US
-                              type: string
-                            L:
-                              default: Raleigh
-                              type: string
-                            O:
-                              default: Hyperledger
-                              type: string
-                            OU:
-                              default: Fabric
-                              type: string
-                            ST:
-                              default: North Carolina
-                              type: string
-                          required:
-                          - C
-                          - L
-                          - O
-                          - OU
-                          - ST
-                          type: object
-                        type: array
-                    required:
-                    - ca
-                    - cn
-                    - hosts
-                    - names
-                    type: object
-                  intermediate:
-                    properties:
-                      parentServer:
-                        properties:
-                          caName:
-                            description: FabricCA Name of the organization
-                            type: string
-                          url:
-                            type: string
-                        required:
-                        - caName
-                        - url
-                        type: object
-                    required:
-                    - parentServer
-                    type: object
-                  name:
-                    type: string
-                  registry:
-                    properties:
-                      identities:
-                        items:
-                          properties:
-                            affiliation:
-                              default: ""
-                              type: string
-                            attrs:
-                              properties:
-                                hf.AffiliationMgr:
-                                  default: true
-                                  type: boolean
-                                hf.GenCRL:
-                                  default: true
-                                  type: boolean
-                                hf.IntermediateCA:
-                                  default: true
-                                  type: boolean
-                                hf.Registrar.Attributes:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.DelegateRoles:
-                                  default: '*'
-                                  type: string
-                                hf.Registrar.Roles:
-                                  default: '*'
-                                  type: string
-                                hf.Revoker:
-                                  default: true
-                                  type: boolean
-                              required:
-                              - hf.AffiliationMgr
-                              - hf.GenCRL
-                              - hf.IntermediateCA
-                              - hf.Registrar.Attributes
-                              - hf.Registrar.DelegateRoles
-                              - hf.Registrar.Roles
-                              - hf.Revoker
-                              type: object
-                            name:
-                              type: string
-                            pass:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - affiliation
-                          - attrs
-                          - name
-                          - pass
-                          - type
-                          type: object
-                        type: array
-                      max_enrollments:
-                        type: integer
-                    required:
-                    - identities
-                    - max_enrollments
-                    type: object
-                  signing:
-                    nullable: true
-                    properties:
-                      default:
-                        properties:
-                          expiry:
-                            default: 8760h
-                            type: string
-                          usage:
-                            default:
-                            - digital signature
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - expiry
-                        - usage
-                        type: object
-                      profiles:
-                        properties:
-                          ca:
-                            properties:
-                              caconstraint:
-                                properties:
-                                  isCA:
-                                    default: true
-                                    type: boolean
-                                  maxPathLen:
-                                    default: 0
-                                    type: integer
-                                required:
-                                - isCA
-                                - maxPathLen
-                                type: object
-                              expiry:
-                                default: 43800h
-                                type: string
-                              usage:
-                                default:
-                                - cert sign
-                                - crl sign
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - caconstraint
-                            - expiry
-                            - usage
-                            type: object
-                          tls:
-                            properties:
-                              expiry:
-                                default: 8760h
-                                type: string
-                              usage:
-                                default:
-                                - signing
-                                - key encipherment
-                                - server auth
-                                - client auth
-                                - key agreement
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - expiry
-                            - usage
-                            type: object
-                        required:
-                        - ca
-                        - tls
-                        type: object
-                    required:
-                    - default
-                    - profiles
-                    type: object
-                  subject:
-                    properties:
-                      C:
-                        default: US
-                        type: string
-                      L:
-                        default: Raleigh
-                        type: string
-                      O:
-                        default: Hyperledger
-                        type: string
-                      OU:
-                        default: Fabric
-                        type: string
-                      ST:
-                        default: North Carolina
-                        type: string
-                      cn:
-                        default: ca
-                        type: string
-                    required:
-                    - C
-                    - L
-                    - O
-                    - OU
-                    - ST
-                    - cn
-                    type: object
-                  tlsCa:
-                    nullable: true
-                    properties:
-                      cert:
-                        type: string
-                      clientAuth:
-                        properties:
-                          cert_file:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            description: NoClientCert, RequestClientCert, RequireAnyClientCert,
-                              VerifyClientCertIfGiven and RequireAndVerifyClientCert.
-                            type: string
-                        required:
-                        - cert_file
-                        - type
-                        type: object
-                      key:
-                        type: string
-                    required:
-                    - cert
-                    - clientAuth
-                    - key
-                    type: object
-                required:
-                - bccsp
-                - cfg
-                - crl
-                - csr
-                - intermediate
-                - name
-                - registry
-                - subject
-                type: object
+              tag:
+                type: string
               tolerations:
                 items:
                   description: The pod this Toleration is attached to tolerates any
@@ -2023,31 +1143,18 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              version:
-                minLength: 1
-                type: string
             required:
-            - ca
-            - clrSizeLimit
-            - cors
-            - db
-            - debug
-            - hosts
+            - apiUrl
             - image
-            - metrics
-            - resources
-            - rootCA
-            - service
-            - storage
-            - tlsCA
-            - version
+            - imagePullPolicy
+            - ingress
+            - logoUrl
+            - replicas
+            - tag
             type: object
           status:
-            description: FabricCAStatus defines the observed state of FabricCA
+            description: FabricOperatorUIStatus defines the observed state of FabricOperatorUI
             properties:
-              ca_cert:
-                description: Root certificate for Sign certificates generated by FabricCA
-                type: string
               conditions:
                 description: Conditions is a set of Condition instances.
                 items:
@@ -2090,24 +1197,13 @@ spec:
                 type: array
               message:
                 type: string
-              nodePort:
-                type: integer
               status:
                 description: Status of the FabricCA
                 type: string
-              tls_cert:
-                description: TLS Certificate to connect to the FabricCA
-                type: string
-              tlsca_cert:
-                description: Root certificate for TLS certificates generated by FabricCA
-                type: string
             required:
-            - ca_cert
             - conditions
             - message
             - status
-            - tls_cert
-            - tlsca_cert
             type: object
         type: object
     served: true

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricorderernodes.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricorderernodes.yaml
@@ -45,6 +45,25 @@ spec:
           spec:
             description: FabricOrdererNodeSpec defines the desired state of FabricOrdererNode
             properties:
+              adminGatewayApi:
+                nullable: true
+                properties:
+                  gatewayName:
+                    type: string
+                  gatewayNamespace:
+                    type: string
+                  hosts:
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  port:
+                    nullable: true
+                    type: integer
+                required:
+                - gatewayName
+                - gatewayNamespace
+                type: object
               adminIstio:
                 nullable: true
                 properties:
@@ -61,12 +80,1034 @@ spec:
                 required:
                 - ingressGateway
                 type: object
+              affinity:
+                description: Affinity is a group of affinity scheduling rules.
+                nullable: true
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
               bootstrapMethod:
                 type: string
               channelParticipationEnabled:
                 type: boolean
+              env:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                nullable: true
+                type: array
+              gatewayApi:
+                nullable: true
+                properties:
+                  gatewayName:
+                    type: string
+                  gatewayNamespace:
+                    type: string
+                  hosts:
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  port:
+                    nullable: true
+                    type: integer
+                required:
+                - gatewayName
+                - gatewayNamespace
+                type: object
               genesis:
                 type: string
+              grpcProxy:
+                nullable: true
+                properties:
+                  enabled:
+                    default: false
+                    type: boolean
+                  image:
+                    default: ghcr.io/hyperledger-labs/grpc-web
+                    type: string
+                  imagePullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  istio:
+                    properties:
+                      hosts:
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      ingressGateway:
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                    required:
+                    - ingressGateway
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  tag:
+                    default: latest
+                    type: string
+                required:
+                - enabled
+                - image
+                - imagePullPolicy
+                - istio
+                - resources
+                - tag
+                type: object
               hostAliases:
                 items:
                   description: HostAlias holds the mapping between IP and hostnames
@@ -86,6 +1127,18 @@ spec:
               image:
                 minLength: 1
                 type: string
+              imagePullSecrets:
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                nullable: true
+                type: array
               istio:
                 nullable: true
                 properties:
@@ -105,6 +1158,91 @@ spec:
               mspID:
                 minLength: 3
                 type: string
+              nodeSelector:
+                description: A node selector represents the union of the results of
+                  one or more label queries over a set of nodes; that is, it represents
+                  the OR of the selectors represented by the node selector terms.
+                nullable: true
+                properties:
+                  nodeSelectorTerms:
+                    description: Required. A list of node selector terms. The terms
+                      are ORed.
+                    items:
+                      description: A null or empty node selector term matches no objects.
+                        The requirements of them are ANDed. The TopologySelectorTerm
+                        type implements a subset of the NodeSelectorTerm.
+                      properties:
+                        matchExpressions:
+                          description: A list of node selector requirements by node's
+                            labels.
+                          items:
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies
+                                  to.
+                                type: string
+                              operator:
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchFields:
+                          description: A list of node selector requirements by node's
+                            fields.
+                          items:
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies
+                                  to.
+                                type: string
+                              operator:
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                required:
+                - nodeSelectorTerms
+                type: object
               pullPolicy:
                 default: IfNotPresent
                 description: PullPolicy describes a policy for if/when to pull a container
@@ -124,7 +1262,7 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -136,7 +1274,7 @@ spec:
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               secret:
@@ -167,6 +1305,26 @@ spec:
                           enrollsecret:
                             minLength: 1
                             type: string
+                          external:
+                            nullable: true
+                            properties:
+                              certificateKey:
+                                type: string
+                              privateKeyKey:
+                                type: string
+                              rootCertificateKey:
+                                type: string
+                              secretName:
+                                type: string
+                              secretNamespace:
+                                type: string
+                            required:
+                            - certificateKey
+                            - privateKeyKey
+                            - rootCertificateKey
+                            - secretName
+                            - secretNamespace
+                            type: object
                         required:
                         - cahost
                         - caname
@@ -203,6 +1361,26 @@ spec:
                             type: string
                           enrollsecret:
                             type: string
+                          external:
+                            nullable: true
+                            properties:
+                              certificateKey:
+                                type: string
+                              privateKeyKey:
+                                type: string
+                              rootCertificateKey:
+                                type: string
+                              secretName:
+                                type: string
+                              secretNamespace:
+                                type: string
+                            required:
+                            - certificateKey
+                            - privateKeyKey
+                            - rootCertificateKey
+                            - secretName
+                            - secretNamespace
+                            type: object
                         required:
                         - cahost
                         - caname
@@ -274,6 +1452,46 @@ spec:
               tag:
                 minLength: 1
                 type: string
+              tolerations:
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
               updateCertificateTime:
                 format: date-time
                 nullable: true

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricorderingservices.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricorderingservices.yaml
@@ -70,6 +70,26 @@ spec:
                       enrollsecret:
                         minLength: 1
                         type: string
+                      external:
+                        nullable: true
+                        properties:
+                          certificateKey:
+                            type: string
+                          privateKeyKey:
+                            type: string
+                          rootCertificateKey:
+                            type: string
+                          secretName:
+                            type: string
+                          secretNamespace:
+                            type: string
+                        required:
+                        - certificateKey
+                        - privateKeyKey
+                        - rootCertificateKey
+                        - secretName
+                        - secretNamespace
+                        type: object
                     required:
                     - cahost
                     - caname
@@ -106,6 +126,26 @@ spec:
                         type: string
                       enrollsecret:
                         type: string
+                      external:
+                        nullable: true
+                        properties:
+                          certificateKey:
+                            type: string
+                          privateKeyKey:
+                            type: string
+                          rootCertificateKey:
+                            type: string
+                          secretName:
+                            type: string
+                          secretNamespace:
+                            type: string
+                        required:
+                        - certificateKey
+                        - privateKeyKey
+                        - rootCertificateKey
+                        - secretName
+                        - secretNamespace
+                        type: object
                     required:
                     - cahost
                     - caname

--- a/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricpeers.yaml
+++ b/chart/hlf-operator/templates/crds/hlf.kungfusoftware.es_fabricpeers.yaml
@@ -45,6 +45,824 @@ spec:
           spec:
             description: FabricPeerSpec defines the desired state of FabricPeer
             properties:
+              affinity:
+                description: Affinity is a group of affinity scheduling rules.
+                nullable: true
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
               couchDBexporter:
                 nullable: true
                 properties:
@@ -84,12 +902,26 @@ spec:
                     - host
                     - port
                     type: object
+                  image:
+                    default: couchdb
+                    type: string
                   password:
+                    type: string
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  tag:
+                    default: 3.1.1
                     type: string
                   user:
                     type: string
                 required:
+                - image
                 - password
+                - pullPolicy
+                - tag
                 - user
                 type: object
               discovery:
@@ -105,6 +937,111 @@ spec:
               dockerSocketPath:
                 default: ""
                 type: string
+              env:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                nullable: true
+                type: array
               external_chaincode_builder:
                 type: boolean
               externalBuilders:
@@ -127,6 +1064,44 @@ spec:
                 type: array
               externalEndpoint:
                 type: string
+              fsServer:
+                nullable: true
+                properties:
+                  image:
+                    default: quay.io/kfsoftware/fs-peer
+                    type: string
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  tag:
+                    default: amd64-2.2.0
+                    type: string
+                required:
+                - image
+                - pullPolicy
+                - tag
+                type: object
+              gatewayApi:
+                nullable: true
+                properties:
+                  gatewayName:
+                    type: string
+                  gatewayNamespace:
+                    type: string
+                  hosts:
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  port:
+                    nullable: true
+                    type: integer
+                required:
+                - gatewayName
+                - gatewayNamespace
+                type: object
               gossip:
                 properties:
                   bootstrap:
@@ -145,6 +1120,86 @@ spec:
                 - externalEndpoint
                 - orgLeader
                 - useLeaderElection
+                type: object
+              grpcProxy:
+                nullable: true
+                properties:
+                  enabled:
+                    default: false
+                    type: boolean
+                  image:
+                    default: ghcr.io/hyperledger-labs/grpc-web
+                    type: string
+                  imagePullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  istio:
+                    properties:
+                      hosts:
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      ingressGateway:
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                    required:
+                    - ingressGateway
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  tag:
+                    default: latest
+                    type: string
+                required:
+                - enabled
+                - image
+                - imagePullPolicy
+                - istio
+                - resources
+                - tag
                 type: object
               hostAliases:
                 items:
@@ -174,6 +1229,18 @@ spec:
                 description: PullPolicy describes a policy for if/when to pull a container
                   image
                 type: string
+              imagePullSecrets:
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                nullable: true
+                type: array
               istio:
                 nullable: true
                 properties:
@@ -221,6 +1288,91 @@ spec:
               mspID:
                 minLength: 3
                 type: string
+              nodeSelector:
+                description: A node selector represents the union of the results of
+                  one or more label queries over a set of nodes; that is, it represents
+                  the OR of the selectors represented by the node selector terms.
+                nullable: true
+                properties:
+                  nodeSelectorTerms:
+                    description: Required. A list of node selector terms. The terms
+                      are ORed.
+                    items:
+                      description: A null or empty node selector term matches no objects.
+                        The requirements of them are ANDed. The TopologySelectorTerm
+                        type implements a subset of the NodeSelectorTerm.
+                      properties:
+                        matchExpressions:
+                          description: A list of node selector requirements by node's
+                            labels.
+                          items:
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies
+                                  to.
+                                type: string
+                              operator:
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchFields:
+                          description: A list of node selector requirements by node's
+                            fields.
+                          items:
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies
+                                  to.
+                                type: string
+                              operator:
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                required:
+                - nodeSelectorTerms
+                type: object
               replicas:
                 default: 1
                 type: integer
@@ -238,7 +1390,7 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -250,7 +1402,7 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   couchdb:
@@ -265,7 +1417,7 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -277,7 +1429,7 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   couchdbExporter:
@@ -293,7 +1445,7 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -305,7 +1457,7 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   peer:
@@ -320,7 +1472,7 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -332,7 +1484,35 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  proxy:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                 required:
@@ -367,6 +1547,26 @@ spec:
                           enrollsecret:
                             minLength: 1
                             type: string
+                          external:
+                            nullable: true
+                            properties:
+                              certificateKey:
+                                type: string
+                              privateKeyKey:
+                                type: string
+                              rootCertificateKey:
+                                type: string
+                              secretName:
+                                type: string
+                              secretNamespace:
+                                type: string
+                            required:
+                            - certificateKey
+                            - privateKeyKey
+                            - rootCertificateKey
+                            - secretName
+                            - secretNamespace
+                            type: object
                         required:
                         - cahost
                         - caname
@@ -403,6 +1603,26 @@ spec:
                             type: string
                           enrollsecret:
                             type: string
+                          external:
+                            nullable: true
+                            properties:
+                              certificateKey:
+                                type: string
+                              privateKeyKey:
+                                type: string
+                              rootCertificateKey:
+                                type: string
+                              secretName:
+                                type: string
+                              secretNamespace:
+                                type: string
+                            required:
+                            - certificateKey
+                            - privateKeyKey
+                            - rootCertificateKey
+                            - secretName
+                            - secretNamespace
+                            type: object
                         required:
                         - cahost
                         - caname
@@ -516,6 +1736,46 @@ spec:
               tag:
                 minLength: 1
                 type: string
+              tolerations:
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
               updateCertificateTime:
                 format: date-time
                 nullable: true

--- a/chart/hlf-operator/templates/deployment.yaml
+++ b/chart/hlf-operator/templates/deployment.yaml
@@ -37,6 +37,24 @@ spec:
         - args:
             - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
+  {{ if .Values.certificates.renewal.peer.enabled }}
+            - --auto-renew-peer-certificates
+            - "true"
+            - --auto-renew-peer-certificates-delta
+            - {{ .Values.certificates.renewal.peer.delta | quote }}
+  {{- end }}
+  {{ if .Values.certificates.renewal.orderer.enabled }}
+            - --auto-renew-orderer-certificates
+            - "true"
+            - --auto-renew-orderer-certificates-delta
+            - {{ .Values.certificates.renewal.orderer.delta | quote }}
+  {{- end }}
+  {{ if .Values.certificates.renewal.identity.enabled }}
+            - --auto-renew-identity-certificates
+            - "true"
+            - --auto-renew-identity-certificates-delta
+            - {{ .Values.certificates.renewal.identity.delta | quote }}
+  {{- end }}
           command:
             - /hlf-operator
           image: {{.Values.image.repository}}:{{.Values.image.tag}}

--- a/chart/hlf-operator/templates/rbac.yaml
+++ b/chart/hlf-operator/templates/rbac.yaml
@@ -31,17 +31,37 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+      - tcproutes
+      - tlsroutes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses/status
+      - gateways/status
+      - httproutes/status
+      - tcproutes/status
+      - tlsroutes/status
+    verbs:
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "hlf-operator.fullname" . }}-manager-role
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -49,11 +69,23 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
       - apps
     resources:
       - replicasets
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -61,31 +93,31 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - apps
     resources:
       - deployments
-    verbs:
-      - create
-      - delete
+  - verbs:
       - get
       - list
-      - patch
-      - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - nodes
-    verbs:
+  - verbs:
+      - create
+      - delete
       - get
       - list
+      - patch
+      - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - persistentvolumeclaims
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -93,11 +125,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - pods
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -105,11 +137,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - pods/log
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -117,11 +149,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - pods/status
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -129,11 +161,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - secrets
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -141,11 +173,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - serviceaccounts
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -153,11 +185,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - ""
+    apiGroups:
+      - ''
     resources:
       - services
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -165,11 +197,23 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
+      - ''
+    resources:
+      - ingresses
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
       - apps
     resources:
       - configmaps
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -177,11 +221,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - apps
     resources:
       - deployments
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -189,11 +233,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - apps
     resources:
       - persistentvolumeclaims
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -201,11 +245,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - apps
     resources:
       - pods
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -213,11 +257,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - apps
     resources:
       - pods/log
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -225,11 +269,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - apps
     resources:
       - pods/status
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -237,11 +281,35 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
+      - extensions
+    resources:
+      - ingresses
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
       - apps
     resources:
       - secrets
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -249,11 +317,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - apps
     resources:
       - services
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -261,11 +329,23 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
+      - apps
+    resources:
+      - ingresses
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
       - extensions
     resources:
       - configmaps
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -273,11 +353,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - extensions
     resources:
       - deployments
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -285,11 +365,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - extensions
     resources:
       - persistentvolumeclaims
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -297,11 +377,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - extensions
     resources:
       - pods
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -309,11 +389,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - extensions
     resources:
       - pods/log
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -321,11 +401,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - extensions
     resources:
       - pods/status
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -333,11 +413,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - extensions
     resources:
       - secrets
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -345,11 +425,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - extensions
     resources:
       - services
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -357,130 +437,352 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperationsconsoles
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperationsconsoles/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperationsconsoles/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperatorapis
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperatorapis/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperatorapis/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperatoruis
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperatoruis/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricoperatoruis/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricpeers
-    verbs:
-      - create
-      - delete
+  - verbs:
       - get
-      - list
       - patch
       - update
-      - watch
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricpeers/finalizers
-    verbs:
+  - verbs:
       - get
       - patch
       - update
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricpeers/status
-    verbs:
+  - verbs:
+      - create
+      - delete
       - get
+      - list
       - patch
       - update
-
-  - apiGroups:
+      - watch
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricorderernodes
-    verbs:
-      - create
-      - delete
+  - verbs:
       - get
-      - list
       - patch
       - update
-      - watch
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricorderernodes/finalizers
-    verbs:
+  - verbs:
       - get
       - patch
       - update
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricorderernodes/status
-    verbs:
+  - verbs:
+      - create
+      - delete
       - get
+      - list
       - patch
       - update
-
-
-  - apiGroups:
+      - watch
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricorderingservices
-    verbs:
-      - create
-      - delete
+  - verbs:
       - get
-      - list
       - patch
       - update
-      - watch
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricorderingservices/finalizers
-    verbs:
+  - verbs:
       - get
       - patch
       - update
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabricorderingservices/status
-    verbs:
+  - verbs:
+      - create
+      - delete
       - get
+      - list
       - patch
       - update
-
-
-  - apiGroups:
+      - watch
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabriccas
-    verbs:
-      - create
-      - delete
+  - verbs:
       - get
-      - list
       - patch
       - update
-      - watch
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabriccas/finalizers
-    verbs:
+  - verbs:
       - get
       - patch
       - update
-  - apiGroups:
+    apiGroups:
       - hlf.kungfusoftware.es
     resources:
       - fabriccas/status
-    verbs:
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricnetworkconfigs
+  - verbs:
       - get
       - patch
       - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricnetworkconfigs/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricnetworkconfigs/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricchaincodes
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricchaincodes/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricchaincodes/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricfollowerchannels
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricfollowerchannels/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricfollowerchannels/status
+
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricmainchannels
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricmainchannels/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricmainchannels/status
 
 
-  - apiGroups:
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricidentities
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricidentities/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - hlf.kungfusoftware.es
+    resources:
+      - fabricidentities/status
+
+
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
       - networking.istio.io
     resources:
       - gateways
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -488,11 +790,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - networking.istio.io
     resources:
       - virtualservices
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -500,11 +802,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - monitoring.coreos.com
     resources:
       - servicemonitors
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -512,11 +814,23 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
       - monitoring.coreos.com
     resources:
       - podmonitors
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -524,11 +838,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -536,11 +850,11 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
+    apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterroles
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -548,6 +862,61 @@ rules:
       - patch
       - update
       - watch
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+  - verbs:
+      - get
+      - update
+      - patch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps/status
+  - verbs:
+      - create
+      - patch
+    apiGroups:
+      - ''
+    resources:
+      - events
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+      - tcproutes
+      - tlsroutes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses/status
+      - gateways/status
+      - httproutes/status
+      - tcproutes/status
+      - tlsroutes/status
+    verbs:
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -617,4 +986,3 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: {{.Release.Namespace}}
-

--- a/chart/hlf-operator/values.yaml
+++ b/chart/hlf-operator/values.yaml
@@ -6,9 +6,21 @@ replicaCount: 1
 
 image:
   repository: quay.io/kfsoftware/hlf-operator
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.4.0"
+  tag: "v1.9.0"
+
+certificates:
+  renewal:
+    orderer:
+      enabled: false
+      delta: "720h"
+    peer:
+      enabled: false
+      delta: "720h"
+    identity:
+      enabled: false
+      delta: "720h"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -28,29 +40,34 @@ podAnnotations: {}
 podSecurityContext: {}
 # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
+# runAsNonRoot: true
 # runAsUser: 1000
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-#   memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  - key: kubernetes.azure.com/scalesetpriority
+    operator: Equal
+    value: spot
+    effect: NoSchedule
 
 affinity: {}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:
This PR allows the users to pass the auto-renewal flags while installing the hlf-operator. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
