### PR TITLE
Add transient map arg to chaincode invoke&query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/go-logr/logr v1.2.3
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
@@ -30,6 +31,7 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/lithammer/shortuuid/v3 v3.0.4
 	github.com/mattn/go-sqlite3 v1.14.15
+	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo v1.16.5
@@ -44,6 +46,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.5.0
+	google.golang.org/grpc v1.49.0
 	gopkg.in/ldap.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -55,6 +58,7 @@ require (
 	k8s.io/client-go v0.26.0
 	k8s.io/kubernetes v1.13.0
 	sigs.k8s.io/controller-runtime v0.12.3
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -108,7 +112,6 @@ require (
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
@@ -141,7 +144,6 @@ require (
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -197,7 +199,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
@@ -213,7 +214,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
 replace (

--- a/kubectl-hlf/cmd/chaincode/invoke.go
+++ b/kubectl-hlf/cmd/chaincode/invoke.go
@@ -1,14 +1,16 @@
 package chaincode
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/kfsoftware/hlf-operator/kubectl-hlf/cmd/helpers"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 type invokeChaincodeCmd struct {
@@ -19,6 +21,7 @@ type invokeChaincodeCmd struct {
 	chaincode  string
 	fcn        string
 	args       []string
+	transient  string
 }
 
 func (c *invokeChaincodeCmd) validate() error {
@@ -57,12 +60,18 @@ func (c *invokeChaincodeCmd) run(out io.Writer) error {
 		args = append(args, []byte(arg))
 	}
 
+	var transientMap map[string][]byte
+	err = json.Unmarshal([]byte(c.transient), &transientMap)
+	if err != nil {
+		return err
+	}
+
 	response, err := ch.Execute(
 		channel.Request{
 			ChaincodeID:     c.chaincode,
 			Fcn:             c.fcn,
 			Args:            args,
-			TransientMap:    nil,
+			TransientMap:    transientMap,
 			InvocationChain: nil,
 			IsInit:          false,
 		},
@@ -96,6 +105,7 @@ func newInvokeChaincodeCMD(out io.Writer, errOut io.Writer) *cobra.Command {
 	persistentFlags.StringVarP(&c.chaincode, "chaincode", "", "", "Chaincode label")
 	persistentFlags.StringVarP(&c.fcn, "fcn", "", "", "Function name")
 	persistentFlags.StringArrayVarP(&c.args, "args", "a", []string{}, "Function arguments")
+	persistentFlags.StringVarP(&c.transient, "transient", "t", "", "Transient map")
 	cmd.MarkPersistentFlagRequired("user")
 	cmd.MarkPersistentFlagRequired("peer")
 	cmd.MarkPersistentFlagRequired("config")

--- a/kubectl-hlf/cmd/chaincode/invoke.go
+++ b/kubectl-hlf/cmd/chaincode/invoke.go
@@ -59,7 +59,6 @@ func (c *invokeChaincodeCmd) run(out io.Writer) error {
 	for _, arg := range c.args {
 		args = append(args, []byte(arg))
 	}
-
 	var transientMap map[string][]byte
 	err = json.Unmarshal([]byte(c.transient), &transientMap)
 	if err != nil {

--- a/kubectl-hlf/cmd/chaincode/query.go
+++ b/kubectl-hlf/cmd/chaincode/query.go
@@ -1,13 +1,15 @@
 package chaincode
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/kfsoftware/hlf-operator/kubectl-hlf/cmd/helpers"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 type queryChaincodeCmd struct {
@@ -18,6 +20,7 @@ type queryChaincodeCmd struct {
 	chaincode  string
 	fcn        string
 	args       []string
+	transient  string
 }
 
 func (c *queryChaincodeCmd) validate() error {
@@ -56,12 +59,19 @@ func (c *queryChaincodeCmd) run(out io.Writer) error {
 	for _, arg := range c.args {
 		args = append(args, []byte(arg))
 	}
+
+	var transientMap map[string][]byte
+	err = json.Unmarshal([]byte(c.transient), &transientMap)
+	if err != nil {
+		return err
+	}
+
 	response, err := ch.Query(
 		channel.Request{
 			ChaincodeID:     c.chaincode,
 			Fcn:             c.fcn,
 			Args:            args,
-			TransientMap:    nil,
+			TransientMap:    transientMap,
 			InvocationChain: nil,
 			IsInit:          false,
 		},

--- a/kubectl-hlf/cmd/chaincode/query.go
+++ b/kubectl-hlf/cmd/chaincode/query.go
@@ -59,7 +59,6 @@ func (c *queryChaincodeCmd) run(out io.Writer) error {
 	for _, arg := range c.args {
 		args = append(args, []byte(arg))
 	}
-
 	var transientMap map[string][]byte
 	err = json.Unmarshal([]byte(c.transient), &transientMap)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
In fabric peer (https://github.com/hyperledger/fabric/blob/main/internal/peer/chaincode), users can set transient map with argument `--transient`. 
In code -> https://github.com/hyperledger/fabric/blob/58b6dc3651e99db7e3eaa61285cac4c5b3cdef4d/internal/peer/chaincode/common.go#L579

There is no equivalent parameter in `kubectl hlf chaincode`. This pr solves that. 

#### Which issue(s) this PR fixes:
There is not any issue related with this problem.

#### Does this PR introduce a user-facing change?
Yes, users can set transient map in chaincode query&invoke comamnds.
