### PR TITLE
Add transient map arg to chaincode invoke&query

### DIFF
--- a/kubectl-hlf/cmd/chaincode/invoke.go
+++ b/kubectl-hlf/cmd/chaincode/invoke.go
@@ -60,9 +60,11 @@ func (c *invokeChaincodeCmd) run(out io.Writer) error {
 		args = append(args, []byte(arg))
 	}
 	var transientMap map[string][]byte
-	err = json.Unmarshal([]byte(c.transient), &transientMap)
-	if err != nil {
-		return err
+	if c.transient != "" {
+		err = json.Unmarshal([]byte(c.transient), &transientMap)
+		if err != nil {
+			return err
+		}
 	}
 
 	response, err := ch.Execute(

--- a/kubectl-hlf/cmd/chaincode/invoke.go
+++ b/kubectl-hlf/cmd/chaincode/invoke.go
@@ -1,14 +1,16 @@
 package chaincode
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/kfsoftware/hlf-operator/kubectl-hlf/cmd/helpers"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 type invokeChaincodeCmd struct {
@@ -19,6 +21,7 @@ type invokeChaincodeCmd struct {
 	chaincode  string
 	fcn        string
 	args       []string
+	transient  string
 }
 
 func (c *invokeChaincodeCmd) validate() error {
@@ -56,13 +59,18 @@ func (c *invokeChaincodeCmd) run(out io.Writer) error {
 	for _, arg := range c.args {
 		args = append(args, []byte(arg))
 	}
+	var transientMap map[string][]byte
+	err = json.Unmarshal([]byte(c.transient), &transientMap)
+	if err != nil {
+		return err
+	}
 
 	response, err := ch.Execute(
 		channel.Request{
 			ChaincodeID:     c.chaincode,
 			Fcn:             c.fcn,
 			Args:            args,
-			TransientMap:    nil,
+			TransientMap:    transientMap,
 			InvocationChain: nil,
 			IsInit:          false,
 		},
@@ -96,6 +104,7 @@ func newInvokeChaincodeCMD(out io.Writer, errOut io.Writer) *cobra.Command {
 	persistentFlags.StringVarP(&c.chaincode, "chaincode", "", "", "Chaincode label")
 	persistentFlags.StringVarP(&c.fcn, "fcn", "", "", "Function name")
 	persistentFlags.StringArrayVarP(&c.args, "args", "a", []string{}, "Function arguments")
+	persistentFlags.StringVarP(&c.transient, "transient", "t", "", "Transient map")
 	cmd.MarkPersistentFlagRequired("user")
 	cmd.MarkPersistentFlagRequired("peer")
 	cmd.MarkPersistentFlagRequired("config")

--- a/kubectl-hlf/cmd/chaincode/query.go
+++ b/kubectl-hlf/cmd/chaincode/query.go
@@ -60,9 +60,11 @@ func (c *queryChaincodeCmd) run(out io.Writer) error {
 		args = append(args, []byte(arg))
 	}
 	var transientMap map[string][]byte
-	err = json.Unmarshal([]byte(c.transient), &transientMap)
-	if err != nil {
-		return err
+	if c.transient != "" {
+		err = json.Unmarshal([]byte(c.transient), &transientMap)
+		if err != nil {
+			return err 
+		}
 	}
 
 	response, err := ch.Query(

--- a/kubectl-hlf/cmd/chaincode/query.go
+++ b/kubectl-hlf/cmd/chaincode/query.go
@@ -1,13 +1,15 @@
 package chaincode
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/kfsoftware/hlf-operator/kubectl-hlf/cmd/helpers"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 type queryChaincodeCmd struct {
@@ -18,6 +20,7 @@ type queryChaincodeCmd struct {
 	chaincode  string
 	fcn        string
 	args       []string
+	transient  string
 }
 
 func (c *queryChaincodeCmd) validate() error {
@@ -56,12 +59,18 @@ func (c *queryChaincodeCmd) run(out io.Writer) error {
 	for _, arg := range c.args {
 		args = append(args, []byte(arg))
 	}
+	var transientMap map[string][]byte
+	err = json.Unmarshal([]byte(c.transient), &transientMap)
+	if err != nil {
+		return err
+	}
+
 	response, err := ch.Query(
 		channel.Request{
 			ChaincodeID:     c.chaincode,
 			Fcn:             c.fcn,
 			Args:            args,
-			TransientMap:    nil,
+			TransientMap:    transientMap,
 			InvocationChain: nil,
 			IsInit:          false,
 		},
@@ -95,6 +104,7 @@ func newQueryChaincodeCMD(out io.Writer, errOut io.Writer) *cobra.Command {
 	persistentFlags.StringVarP(&c.chaincode, "chaincode", "", "", "Chaincode label")
 	persistentFlags.StringVarP(&c.fcn, "fcn", "", "", "Function name")
 	persistentFlags.StringArrayVarP(&c.args, "args", "a", []string{}, "Function arguments")
+	persistentFlags.StringVarP(&c.transient, "transient", "t", "", "Transient map")
 	cmd.MarkPersistentFlagRequired("user")
 	cmd.MarkPersistentFlagRequired("peer")
 	cmd.MarkPersistentFlagRequired("config")


### PR DESCRIPTION
#### What this PR does / why we need it:
In fabric peer chaincode (https://github.com/hyperledger/fabric/blob/main/internal/peer/chaincode), users can set transient map with argument `--transient`. 
In code -> https://github.com/hyperledger/fabric/blob/58b6dc3651e99db7e3eaa61285cac4c5b3cdef4d/internal/peer/chaincode/common.go#L579

There is no equivalent parameter in `kubectl hlf chaincode`. This pr solves that. 

#### Which issue(s) this PR fixes:
There is not any issue related with this problem.

#### Does this PR introduce a user-facing change?
Yes, users can set transient map in chaincode query&invoke comamnds.

#### Usage:
It can be used with -t parameter in `kubectl hlf chaincode invoke/query` commands. 
Example for creating bid in https://github.com/hyperledger/fabric-samples/blob/main/auction-simple chaincode:
```
kubectl hlf chaincode invoke --config=resources/network.yaml \
    --user=admin --peer=org1-peer0.default \
    --chaincode=auction-simple --channel=demo \
    --fcn=Bid -a "auction_id_test"
    -t= "{\"bid\":{\"objectType\": \"bid\", \"price\": 250, \"org\": \"Org1MSP\", \"bidder\": \"admin\"}}
```
