### PR TITLE
Update Go module version and enhance inspect command functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kfsoftware/hlf-operator
 
-go 1.22.5
+go 1.23.5
 
 require (
 	github.com/IBM/idemix v0.0.0-20220113150823-80dd4cb2d74e
@@ -233,5 +233,5 @@ require (
 
 replace (
 	github.com/hyperledger/fabric-config => github.com/kfsoftware/fabric-config v0.0.0-20240819184344-a0b16ca530c2
-	github.com/hyperledger/fabric-sdk-go => github.com/kfsoftware/fabric-sdk-go v0.0.0-20240114221414-98466038585d
+	github.com/hyperledger/fabric-sdk-go => github.com/kfsoftware/fabric-sdk-go v0.0.0-20250318193343-db7cb6f42306
 )

--- a/go.sum
+++ b/go.sum
@@ -517,6 +517,8 @@ github.com/kfsoftware/fabric-config v0.0.0-20240819184344-a0b16ca530c2 h1:6wb4m/
 github.com/kfsoftware/fabric-config v0.0.0-20240819184344-a0b16ca530c2/go.mod h1:1ZfjDrsuMoM4IPKezQgTByy2vXUj8bgTXaOXaGXK5O4=
 github.com/kfsoftware/fabric-sdk-go v0.0.0-20240114221414-98466038585d h1:HcMV8Lve3QkZUIWYHP+rVIR4xtTdDPooj7Id0IdBj0o=
 github.com/kfsoftware/fabric-sdk-go v0.0.0-20240114221414-98466038585d/go.mod h1:JRplpKBeAvXjsBhOCCM/KvMRUbdDyhsAh80qbXzKc10=
+github.com/kfsoftware/fabric-sdk-go v0.0.0-20250318193343-db7cb6f42306 h1:1HeRlKS4qdrC26HAe8ZqRiuBUPiGFDY7taHuehyraRE=
+github.com/kfsoftware/fabric-sdk-go v0.0.0-20250318193343-db7cb6f42306/go.mod h1:JRplpKBeAvXjsBhOCCM/KvMRUbdDyhsAh80qbXzKc10=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
- Bump Go version from 1.22.5 to 1.23.5 in go.mod.
- Update fabric-sdk-go dependency to a newer version in go.mod and go.sum.
- Modify inspect command to support fetching genesis blocks and outputting raw block data in addition to JSON format.

These changes improve compatibility with the latest Go version and enhance the functionality of the channel inspection command.