### PR TITLE
Add environment variable support for external chaincode commands

### DIFF
--- a/kubectl-hlf/cmd/externalchaincode/sync.go
+++ b/kubectl-hlf/cmd/externalchaincode/sync.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
+
 	"github.com/kfsoftware/hlf-operator/kubectl-hlf/cmd/helpers"
 	"github.com/kfsoftware/hlf-operator/pkg/apis/hlf.kungfusoftware.es/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 type syncExternalChaincodeCmd struct {

--- a/kubectl-hlf/cmd/externalchaincode/update.go
+++ b/kubectl-hlf/cmd/externalchaincode/update.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
+
 	"github.com/kfsoftware/hlf-operator/kubectl-hlf/cmd/helpers"
 	"github.com/kfsoftware/hlf-operator/pkg/apis/hlf.kungfusoftware.es/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 type updateExternalChaincodeCmd struct {
@@ -27,6 +28,7 @@ type updateExternalChaincodeCmd struct {
 	replicas int
 
 	tlsRequired bool
+	Env         []string
 }
 
 func (c *updateExternalChaincodeCmd) validate() error {
@@ -82,6 +84,13 @@ func (c *updateExternalChaincodeCmd) run() error {
 	fabricChaincode.Spec.PackageID = c.packageID
 	fabricChaincode.Spec.ImagePullSecrets = []corev1.LocalObjectReference{}
 	fabricChaincode.Spec.Replicas = c.replicas
+	if len(c.Env) > 0 {
+		env, err := c.handleEnv()
+		if err != nil {
+			return err
+		}
+		fabricChaincode.Spec.Env = env
+	}
 	if c.tlsRequired {
 		fabricCA, err := oclient.HlfV1alpha1().FabricCAs(c.caNamespace).Get(ctx, c.caName, v1.GetOptions{})
 		if err != nil {
@@ -118,6 +127,22 @@ func (c *updateExternalChaincodeCmd) run() error {
 	fmt.Printf("Updated external chaincode %s\n", fabricChaincode.Name)
 	return nil
 }
+
+func (c *updateExternalChaincodeCmd) handleEnv() ([]corev1.EnvVar, error) {
+	var env []corev1.EnvVar
+	for _, literalSource := range c.Env {
+		keyName, value, err := ParseEnv(literalSource)
+		if err != nil {
+			return nil, err
+		}
+		env = append(env, corev1.EnvVar{
+			Name:  keyName,
+			Value: value,
+		})
+	}
+	return env, nil
+}
+
 func newExternalChaincodeUpdateCmd() *cobra.Command {
 	c := &updateExternalChaincodeCmd{}
 	cmd := &cobra.Command{
@@ -141,5 +166,6 @@ func newExternalChaincodeUpdateCmd() *cobra.Command {
 	f.BoolVarP(&c.force, "force", "", false, "Force restart of chaincode")
 	f.IntVar(&c.replicas, "replicas", 1, "Replicas of the chaincode")
 	f.BoolVar(&c.tlsRequired, "tls-required", false, "Require TLS for chaincode")
+	f.StringArrayVarP(&c.Env, "env", "", []string{}, "Environment variable for the Chaincode (key=value)")
 	return cmd
 }


### PR DESCRIPTION
- Introduced an `Env` field to the `createExternalChaincodeCmd` and `updateExternalChaincodeCmd` structs to allow users to specify environment variables for the chaincode.
- Implemented `handleEnv` method to parse and set environment variables from the provided input.
- Updated command flags to include `--env` option for both create and update commands.

These changes enhance the flexibility of external chaincode configuration by allowing custom environment variables to be passed during creation and updates.

