### PR TITLE
Add current time metric and update mechanism

### DIFF
--- a/controllers/hlfmetrics/metrics.go
+++ b/controllers/hlfmetrics/metrics.go
@@ -2,6 +2,8 @@ package hlfmetrics
 
 import (
 	"crypto/x509"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -12,6 +14,13 @@ var (
 			Help: "The date after which the certificate expires. Expressed as a Unix Epoch Time.",
 		},
 		[]string{"node_type", "crt_type", "namespace", "name"},
+	)
+
+	CurrentTimeSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "hlf_operator_current_time_seconds",
+			Help: "The current time in Unix Epoch Time.",
+		},
 	)
 )
 
@@ -30,4 +39,8 @@ func UpdateCertificateExpiry(
 		"node_type": nodeType,
 		"crt_type":  crtType,
 	}).Set(expiryTime)
+}
+
+func UpdateCurrentTime() {
+	CurrentTimeSeconds.Set(float64(time.Now().Unix()))
 }

--- a/main.go
+++ b/main.go
@@ -126,6 +126,16 @@ func main() {
 	}
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(hlfmetrics.CertificateExpiryTimeSeconds)
+	metrics.Registry.MustRegister(hlfmetrics.CurrentTimeSeconds)
+
+	// Start a goroutine to update the current time metric every second
+	go func() {
+		for {
+			hlfmetrics.UpdateCurrentTime()
+			time.Sleep(time.Second)
+		}
+	}()
+
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:           scheme,
 		LeaderElection:   enableLeaderElection,


### PR DESCRIPTION
- Introduced a new Prometheus gauge metric `CurrentTimeSeconds` to track the current time in Unix Epoch format.
- Implemented a goroutine that updates the `CurrentTimeSeconds` metric every second, ensuring real-time monitoring of the current time.

These changes enhance the observability of the system by providing a metric for the current time, which can be useful for various monitoring and alerting purposes.
