### PR TITLE
Set default CredentialStore to "kubernetes" in multiple controllers

### DIFF
--- a/controllers/ca/ca_controller.go
+++ b/controllers/ca/ca_controller.go
@@ -1108,7 +1108,9 @@ func Reconcile(
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-
+	if hlf.Spec.CredentialStore == "" {
+		hlf.Spec.CredentialStore = "kubernetes"
+	}
 	if exists {
 		// update
 		log.Debugf("Release %s exists, updating", releaseName)

--- a/controllers/identity/identity_controller.go
+++ b/controllers/identity/identity_controller.go
@@ -121,6 +121,9 @@ func (r *FabricIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, err
 		}
 	}
+	if fabricIdentity.Spec.CredentialStore == "" {
+		fabricIdentity.Spec.CredentialStore = "kubernetes"
+	}
 	clientSet, err := utils.GetClientKubeWithConf(r.Config)
 	if err != nil {
 		r.setConditionStatus(ctx, fabricIdentity, hlfv1alpha1.FailedStatus, false, err, false)

--- a/controllers/ordnode/ordnode_controller.go
+++ b/controllers/ordnode/ordnode_controller.go
@@ -144,6 +144,9 @@ func (r *FabricOrdererNodeReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 	}
+	if fabricOrdererNode.Spec.CredentialStore == "" {
+		fabricOrdererNode.Spec.CredentialStore = "kubernetes"
+	}
 	cmdStatus := action.NewStatus(cfg)
 	exists := true
 	helmStatus, err := cmdStatus.Run(releaseName)
@@ -757,7 +760,7 @@ func ReenrollTLSCryptoMaterial(
 			return nil, nil, nil, err
 		}
 		return tlsCert, tlsKey, tlsRootCert, nil
-	} else if conf.Spec.CredentialStore == hlfv1alpha1.CredentialStoreKubernetes {
+	} else {
 		reenrollRequest, err := getReenrollRequestForFabricCATLS(client, enrollment, &conf.Spec, "tls")
 		if err != nil {
 			return nil, nil, nil, err
@@ -771,8 +774,6 @@ func ReenrollTLSCryptoMaterial(
 			return nil, nil, nil, err
 		}
 		return tlsCert, tlsKey, tlsRootCert, nil
-	} else {
-		return nil, nil, nil, errors.New(fmt.Sprintf("not implemented for credential store %s", conf.Spec.CredentialStore))
 	}
 }
 

--- a/website-docs/docs/operator-guide/prometheus-metrics.md
+++ b/website-docs/docs/operator-guide/prometheus-metrics.md
@@ -1,0 +1,131 @@
+---
+id: prometheus-metrics
+title: Prometheus Metrics
+---
+
+# Prometheus Metrics
+
+The HLF Operator exposes several Prometheus metrics that can be used for monitoring and alerting on your Hyperledger Fabric network. These metrics provide insights into certificate expiration times and current system time.
+
+## Available Metrics
+
+### Certificate Expiration Metrics
+
+#### `hlf_operator_certificate_expiration_timestamp_seconds`
+
+**Type:** Gauge Vector  
+**Description:** The date after which the certificate expires, expressed as a Unix Epoch Time.
+
+**Labels:**
+- `node_type`: Type of the Fabric node (e.g., "peer", "orderer", "ca")
+- `crt_type`: Type of certificate (e.g., "tls", "signcert", "cacert")
+- `namespace`: Kubernetes namespace where the resource is deployed
+- `name`: Name of the Fabric resource
+
+**Example:**
+```
+hlf_operator_certificate_expiration_timestamp_seconds{node_type="peer",crt_type="tls",namespace="hlf-network",name="peer0-org1"} 1735689600
+```
+
+### System Time Metrics
+
+#### `hlf_operator_current_time_seconds`
+
+**Type:** Gauge  
+**Description:** The current time in Unix Epoch Time.
+
+**Example:**
+```
+hlf_operator_current_time_seconds 1735689600
+```
+
+## Usage Examples
+
+### Monitoring Certificate Expiration
+
+You can create Prometheus queries to monitor certificate expiration:
+
+```promql
+# Get all certificates expiring within the next 30 days
+hlf_operator_certificate_expiration_timestamp_seconds - hlf_operator_current_time_seconds < 2592000
+
+# Get certificates expiring within the next 7 days
+hlf_operator_certificate_expiration_timestamp_seconds - hlf_operator_current_time_seconds < 604800
+
+# Get certificates by node type
+hlf_operator_certificate_expiration_timestamp_seconds{node_type="peer"}
+
+# Get TLS certificates specifically
+hlf_operator_certificate_expiration_timestamp_seconds{crt_type="tls"}
+```
+
+### Alerting Rules
+
+Here are some example Prometheus alerting rules you can use:
+
+```yaml
+groups:
+  - name: hlf-certificate-alerts
+    rules:
+      - alert: CertificateExpiringSoon
+        expr: (hlf_operator_certificate_expiration_timestamp_seconds - hlf_operator_current_time_seconds) < 604800
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Certificate expiring soon"
+          description: "Certificate for {{ $labels.node_type }} {{ $labels.name }} in namespace {{ $labels.namespace }} will expire in less than 7 days"
+
+      - alert: CertificateExpiringVerySoon
+        expr: (hlf_operator_certificate_expiration_timestamp_seconds - hlf_operator_current_time_seconds) < 86400
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Certificate expiring very soon"
+          description: "Certificate for {{ $labels.node_type }} {{ $labels.name }} in namespace {{ $labels.namespace }} will expire in less than 24 hours"
+```
+
+### Grafana Dashboard Queries
+
+For Grafana dashboards, you can use these queries:
+
+**Certificate Expiration Timeline:**
+```promql
+hlf_operator_certificate_expiration_timestamp_seconds
+```
+
+**Days Until Expiration:**
+```promql
+(hlf_operator_certificate_expiration_timestamp_seconds - hlf_operator_current_time_seconds) / 86400
+```
+
+**Certificates by Node Type:**
+```promql
+count by (node_type) (hlf_operator_certificate_expiration_timestamp_seconds)
+```
+
+## Enabling Metrics Collection
+
+To collect these metrics, ensure that:
+
+1. **ServiceMonitor is enabled** in your Fabric resources:
+   ```yaml
+   serviceMonitor:
+     enabled: true
+     interval: 10s
+     labels: {}
+     sampleLimit: 0
+     scrapeTimeout: 10s
+   ```
+
+2. **Prometheus Operator is installed** in your cluster to automatically discover and scrape the metrics.
+
+3. **Metrics endpoint is accessible** on the HLF Operator service.
+
+## Metric Updates
+
+- **Certificate expiration metrics** are updated whenever certificates are processed or renewed
+- **Current time metric** is updated regularly to provide a reference point for time-based calculations
+
+These metrics help you maintain visibility into your Hyperledger Fabric network's certificate lifecycle and ensure timely certificate renewals to prevent service disruptions. 

--- a/website-docs/sidebars.ts
+++ b/website-docs/sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
 			"operator-guide/increase-resources",
 			"operator-guide/increase-storage",
 			"operator-guide/renew-certificates",
+			"operator-guide/prometheus-metrics",
 			"operator-guide/istio",
 			"operator-guide/upgrade-hlf-operator",
 			"operator-guide/auto-renew-certificates",


### PR DESCRIPTION
- Updated the Reconcile functions in the CA, identity, ordnode, and peer controllers to set the CredentialStore to "kubernetes" if it is not already specified.
- This change ensures a consistent default configuration across different components, enhancing usability and reducing potential misconfigurations.

