### PR TITLE
Enhance chaincode query commands with output format option

### DIFF
--- a/kubectl-hlf/cmd/chaincode/queryapproved.go
+++ b/kubectl-hlf/cmd/chaincode/queryapproved.go
@@ -3,13 +3,14 @@ package chaincode
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/kfsoftware/hlf-operator/kubectl-hlf/cmd/helpers"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 type queryApprovedCmd struct {
@@ -18,6 +19,7 @@ type queryApprovedCmd struct {
 	userName      string
 	channelName   string
 	chaincodeName string
+	output        string
 }
 
 func (c *queryApprovedCmd) validate() error {
@@ -59,6 +61,17 @@ func (c *queryApprovedCmd) run(out io.Writer) error {
 		},
 		resmgmt.WithTargetEndpoints(peerName),
 	)
+	if err != nil {
+		return err
+	}
+	if c.output == "json" {
+		b, err := json.MarshalIndent(chaincode, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(b)
+		return err
+	}
 	signaturePolicyBytes, err := json.Marshal(chaincode.SignaturePolicy)
 	if err != nil {
 		return err
@@ -99,6 +112,7 @@ func newQueryApprovedCMD(out io.Writer, errOut io.Writer) *cobra.Command {
 	persistentFlags.StringVarP(&c.configPath, "config", "", "", "Configuration file for the SDK")
 	persistentFlags.StringVarP(&c.channelName, "channel", "C", "", "Channel name")
 	persistentFlags.StringVarP(&c.chaincodeName, "chaincode", "c", "", "Chaincode label")
+	persistentFlags.StringVarP(&c.output, "output", "o", "table", "Output format, can be table or json")
 	cmd.MarkPersistentFlagRequired("user")
 	cmd.MarkPersistentFlagRequired("peer")
 	cmd.MarkPersistentFlagRequired("config")

--- a/kubectl-hlf/cmd/chaincode/querycommitted.go
+++ b/kubectl-hlf/cmd/chaincode/querycommitted.go
@@ -3,6 +3,8 @@ package chaincode
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
@@ -10,7 +12,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 type queryCommittedCmd struct {
@@ -19,6 +20,7 @@ type queryCommittedCmd struct {
 	userName      string
 	channelName   string
 	chaincodeName string
+	output        string
 }
 
 func (c *queryCommittedCmd) validate() error {
@@ -66,6 +68,14 @@ func (c *queryCommittedCmd) run(out io.Writer) error {
 	if len(chaincodes) == 0 {
 		log.Infof("No chaincode found")
 		return nil
+	}
+	if c.output == "json" {
+		b, err := json.MarshalIndent(chaincodes, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(b)
+		return err
 	}
 	var data [][]string
 	for _, chaincode := range chaincodes {
@@ -121,6 +131,7 @@ func newQueryCommittedCMD(out io.Writer, errOut io.Writer) *cobra.Command {
 	persistentFlags.StringVarP(&c.configPath, "config", "", "", "Configuration file for the SDK")
 	persistentFlags.StringVarP(&c.channelName, "channel", "C", "", "Channel name")
 	persistentFlags.StringVarP(&c.chaincodeName, "chaincode", "c", "", "Chaincode label")
+	persistentFlags.StringVarP(&c.output, "output", "o", "table", "Output format, can be table or json")
 	cmd.MarkPersistentFlagRequired("user")
 	cmd.MarkPersistentFlagRequired("peer")
 	cmd.MarkPersistentFlagRequired("config")

--- a/kubectl-hlf/cmd/chaincode/queryinstalled.go
+++ b/kubectl-hlf/cmd/chaincode/queryinstalled.go
@@ -2,6 +2,8 @@ package chaincode
 
 import (
 	"encoding/json"
+	"io"
+
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
@@ -9,7 +11,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 type queryInstalledCmd struct {
@@ -17,6 +18,7 @@ type queryInstalledCmd struct {
 	peer       string
 	userName   string
 	mspID      string
+	output     string
 }
 
 func (c *queryInstalledCmd) validate() error {
@@ -66,6 +68,14 @@ func (c *queryInstalledCmd) run(out io.Writer) error {
 		log.Infof("No chaincodes installed")
 		return nil
 	}
+	if c.output == "json" {
+		b, err := json.MarshalIndent(chaincodes, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(b)
+		return err
+	}
 	var data [][]string
 	for _, chaincode := range chaincodes {
 		referencesJson, err := json.Marshal(chaincode.References)
@@ -109,6 +119,7 @@ func newChaincodeQueryInstalledCMD(out io.Writer, errOut io.Writer) *cobra.Comma
 	persistentFlags.StringVarP(&c.userName, "user", "", "", "User name for the transaction")
 	persistentFlags.StringVarP(&c.configPath, "config", "", "", "Configuration file for the SDK")
 	persistentFlags.StringVarP(&c.mspID, "mspID", "", "", "MSP ID of the peer")
+	persistentFlags.StringVarP(&c.output, "output", "o", "table", "Output format, can be table or json")
 	cmd.MarkPersistentFlagRequired("user")
 	cmd.MarkPersistentFlagRequired("peer")
 	cmd.MarkPersistentFlagRequired("config")


### PR DESCRIPTION
- Added an `output` flag to the `queryapproved`, `querycommitted`, and `queryinstalled` commands, allowing users to specify the output format as either "table" or "json".
- Implemented JSON output formatting for the queried chaincode data, improving the usability and flexibility of the commands.

These changes enhance the user experience by providing more options for displaying query results.
