### PR TITLE
Fix TLS profile enroll/re-enroll

### DIFF
--- a/kubectl-hlf/cmd/externalchaincode/sync.go
+++ b/kubectl-hlf/cmd/externalchaincode/sync.go
@@ -180,7 +180,7 @@ func (c *syncExternalChaincodeCmd) updateChaincode(ctx context.Context, fabricCh
 		return err
 	}
 	fabricChaincode.Spec.Image = fabricChaincodeSpec.Image
-	fabricChaincode.Spec.ImagePullPolicy = fabricChaincodeSpec.ImagePullPolicy
+	fabricChaincode.Spec.ImagePullPolicy = corev1.PullAlways
 	fabricChaincode.Spec.Replicas = fabricChaincodeSpec.Replicas
 	fabricChaincode.Spec.PackageID = fabricChaincodeSpec.PackageID
 	fabricChaincode.Spec.ImagePullSecrets = fabricChaincodeSpec.ImagePullSecrets


### PR DESCRIPTION
Peers/Orderers since 1.13.0 were not being enrolled and re-enrolled with profile "tls"