### PR TITLE
Add deduplication function for host entries

### DIFF
--- a/controllers/ordnode/ordnode_controller.go
+++ b/controllers/ordnode/ordnode_controller.go
@@ -1525,6 +1525,18 @@ func getEnrollRequestForFabricCA(client *kubernetes.Clientset, enrollment *hlfv1
 	}, nil
 }
 
+func deduplicateHosts(hosts []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, host := range hosts {
+		if host != "" && !seen[host] {
+			seen[host] = true
+			result = append(result, host)
+		}
+	}
+	return result
+}
+
 func getEnrollRequestForFabricCATLS(client *kubernetes.Clientset, enrollment *hlfv1alpha1.TLSComponent, spec *hlfv1alpha1.FabricOrdererNodeSpec, profile string) (certs.EnrollUserRequest, error) {
 	cacert, err := getCertBytesFromCATLS(client, enrollment.Catls)
 	if err != nil {
@@ -1545,6 +1557,7 @@ func getEnrollRequestForFabricCATLS(client *kubernetes.Clientset, enrollment *hl
 	if spec.AdminTraefik != nil {
 		hosts = append(hosts, spec.AdminTraefik.Hosts...)
 	}
+	hosts = deduplicateHosts(hosts)
 	return certs.EnrollUserRequest{
 		Hosts:      hosts,
 		CN:         enrollment.Enrollid,
@@ -1585,6 +1598,7 @@ func getEnrollRequestForVaultTLS(tls *hlfv1alpha1.TLSComponent, conf *hlfv1alpha
 	if conf.Spec.AdminTraefik != nil {
 		hosts = append(hosts, conf.Spec.AdminTraefik.Hosts...)
 	}
+	hosts = deduplicateHosts(hosts)
 	return certs_vault.EnrollUserRequest{
 		MSPID:      conf.Spec.MspID,
 		User:       tls.Enrollid,
@@ -1631,6 +1645,7 @@ func getReenrollRequestForFabricCATLS(client *kubernetes.Clientset, enrollment *
 	if conf.AdminTraefik != nil {
 		hosts = append(hosts, conf.AdminTraefik.Hosts...)
 	}
+	hosts = deduplicateHosts(hosts)
 	tlsCAUrl := fmt.Sprintf("https://%s:%d", enrollment.Cahost, enrollment.Caport)
 	return certs.ReenrollUserRequest{
 		TLSCert:  string(cacert),
@@ -1669,6 +1684,7 @@ func getReenrollRequestForVaultTLS(tls *hlfv1alpha1.TLSComponent, conf *hlfv1alp
 	if conf.Spec.AdminTraefik != nil {
 		hosts = append(hosts, conf.Spec.AdminTraefik.Hosts...)
 	}
+	hosts = deduplicateHosts(hosts)
 
 	return certs_vault.ReenrollUserRequest{
 		MSPID:      conf.Spec.MspID,

--- a/controllers/peer/peer_controller.go
+++ b/controllers/peer/peer_controller.go
@@ -857,6 +857,18 @@ func getExistingSignCrypto(client *kubernetes.Clientset, chartName string, names
 	return crt, key, rootCrt, nil
 }
 
+func deduplicateHosts(hosts []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, host := range hosts {
+		if host != "" && !seen[host] {
+			seen[host] = true
+			result = append(result, host)
+		}
+	}
+	return result
+}
+
 func getEnrollRequestForFabricCA(client *kubernetes.Clientset, enrollment *hlfv1alpha1.Component, conf *hlfv1alpha1.FabricPeer, profile string) (certs.EnrollUserRequest, error) {
 	cacert, err := getCertBytesFromCATLS(client, enrollment.Catls)
 	if err != nil {
@@ -886,6 +898,7 @@ func getEnrollRequestForFabricCATLS(client *kubernetes.Clientset, enrollment *hl
 	var hosts []string
 	hosts = append(hosts, enrollment.Csr.Hosts...)
 	hosts = append(hosts, ingressHosts...)
+	hosts = deduplicateHosts(hosts)
 	return certs.EnrollUserRequest{
 		Hosts:      hosts,
 		CN:         enrollment.Enrollid,
@@ -916,6 +929,7 @@ func getEnrollRequestForVaultTLS(tls *hlfv1alpha1.TLSComponent, conf *hlfv1alpha
 	var hosts []string
 	hosts = append(hosts, tlsParams.Csr.Hosts...)
 	hosts = append(hosts, ingressHosts...)
+	hosts = deduplicateHosts(hosts)
 	return certs_vault.EnrollUserRequest{
 		MSPID:      conf.Spec.MspID,
 		User:       tls.Enrollid,
@@ -1041,6 +1055,7 @@ func getReenrollRequestForFabricCATLS(client *kubernetes.Clientset, enrollment *
 	var hosts []string
 	hosts = append(hosts, tlsParams.Csr.Hosts...)
 	hosts = append(hosts, ingressHosts...)
+	hosts = deduplicateHosts(hosts)
 
 	tlsCAUrl := fmt.Sprintf("https://%s:%d", enrollment.Cahost, enrollment.Caport)
 	return certs.ReenrollUserRequest{
@@ -1070,6 +1085,7 @@ func getReenrollRequestForVaultTLS(tls *hlfv1alpha1.TLSComponent, conf *hlfv1alp
 	var hosts []string
 	hosts = append(hosts, tlsParams.Csr.Hosts...)
 	hosts = append(hosts, ingressHosts...)
+	hosts = deduplicateHosts(hosts)
 	return certs_vault.ReenrollUserRequest{
 		MSPID:      conf.Spec.MspID,
 		Hosts:      hosts,


### PR DESCRIPTION

- Introduced a new `deduplicateHosts` function in both `ordnode_controller.go` and `peer_controller.go` to eliminate duplicate host entries from enrollment requests.
- Updated relevant functions to utilize this new deduplication logic, ensuring cleaner and more efficient host management during certificate enrollment and renewal processes.

These changes enhance the reliability of host handling in the application, preventing potential issues caused by duplicate entries.
