### PR TITLE
add ttl in certs generated using vault

### DIFF
--- a/controllers/certs_vault/provision_certs.go
+++ b/controllers/certs_vault/provision_certs.go
@@ -388,6 +388,11 @@ func ReenrollUser(clientSet *kubernetes.Clientset, spec *hlfv1alpha1.VaultSpecCo
 		csrData["common_name"] = params.CN
 	}
 
+	// Add TTL if specified in the request
+	if request.TTL != "" {
+		csrData["ttl"] = request.TTL
+	}
+
 	// Request certificate from Vault PKI using existing key
 	secret, err := vaultClient.Write(
 		context.Background(),
@@ -472,6 +477,11 @@ func EnrollUser(clientSet *kubernetes.Clientset, vaultConf *hlfv1alpha1.VaultSpe
 		"common_name":         commonName,
 		"use_csr_common_name": true,
 		"use_csr_sans":        true,
+	}
+
+	// Add TTL if specified in the request
+	if request.TTL != "" {
+		csrData["ttl"] = request.TTL
 	}
 
 	// Request certificate from Vault PKI using the CSR


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

When using Vault as the credential store for Hyperledger Fabric components, the TTL (Time-To-Live) parameters specified in the configuration were not being passed to Vault's PKI backend during certificate generation. This resulted in certificates being issued with Vault's default TTL (typically 90 days) instead of the user-specified duration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Added TTL to certificate signing requests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
