### PR TITLE
refactor: introduce unified PKI interface for Fabric CA and Vault

### DIFF
--- a/.github/workflows/test-pki-e2e.yml
+++ b/.github/workflows/test-pki-e2e.yml
@@ -1,0 +1,591 @@
+on:
+  push:
+  pull_request:
+
+name: PKI E2E – FabricCA (peer) + Vault (orderer)
+
+# Single cluster test:
+#   Peer org  → credential-store=kubernetes (FabricCA)
+#   Orderer org → credential-store=vault    (Vault PKI engine)
+#
+# Flow: provision → channel → chaincode → invoke → reenroll both → verify
+
+jobs:
+  mixed-pki:
+    name: Peer=FabricCA, Orderer=Vault
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: hlf-operator
+      TAG: test
+      PEER_IMAGE: hyperledger/fabric-peer
+      PEER_VERSION: 2.5.10
+      ORDERER_IMAGE: hyperledger/fabric-orderer
+      ORDERER_VERSION: 2.5.10
+      CA_IMAGE: hyperledger/fabric-ca
+      CA_VERSION: 1.5.15
+      VAULT_K8S_ADDR: http://vault.default.svc.cluster.local:8200
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.23.5"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+
+
+      # -----------------------------------------------------------------------
+      # Kind cluster + tooling
+      # -----------------------------------------------------------------------
+      - name: Create Kind cluster
+        uses: helm/kind-action@v1.4.0
+        with:
+          cluster_name: kind
+          node_image: kindest/node:v1.29.2
+          config: .github/kind-config.yaml
+
+      - name: Install kubectl-hlf plugin
+        run: |
+          cd kubectl-hlf
+          go build -o kubectl-hlf ./main.go
+          sudo mv kubectl-hlf /usr/local/bin/kubectl-hlf
+
+      - name: Install operator CRDs and deploy
+        run: |
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.4
+          make generate manifests install
+          export GOOS=linux
+          export GOARCH=amd64
+          export CGO_ENABLED=0
+          go build -o hlf-operator ./main.go
+          docker build -t "${IMAGE}:${TAG}" .
+          kind load docker-image "${IMAGE}:${TAG}"
+          make deploy IMG="${IMAGE}:${TAG}"
+
+      - name: Install Istio
+        run: |
+          curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.23.2 TARGET_ARCH=x86_64 sh -
+          export PATH="$PATH:$PWD/istio-1.23.2/bin"
+          kubectl create namespace istio-system
+
+          istioctl operator init
+
+
+          kubectl apply -f - <<EOF
+            apiVersion: install.istio.io/v1alpha1
+            kind: IstioOperator
+            metadata:
+              name: istio-gateway
+              namespace: istio-system
+            spec:
+              addonComponents:
+                grafana:
+                  enabled: false
+                kiali:
+                  enabled: false
+                prometheus:
+                  enabled: false
+                tracing:
+                  enabled: false
+              components:
+                ingressGateways:
+                  - enabled: true
+                    k8s:
+                      hpaSpec:
+                        minReplicas: 1
+                      resources:
+                        limits:
+                          cpu: 500m
+                          memory: 512Mi
+                        requests:
+                          cpu: 100m
+                          memory: 128Mi
+                      service:
+                        ports:
+                          - name: http
+                            port: 80
+                            targetPort: 8080
+                            nodePort: 30949
+                          - name: https
+                            port: 443
+                            targetPort: 8443
+                            nodePort: 30950
+                        type: NodePort
+                    name: istio-ingressgateway
+                pilot:
+                  enabled: true
+                  k8s:
+                    hpaSpec:
+                      minReplicas: 1
+                    resources:
+                      limits:
+                        cpu: 300m
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+              meshConfig:
+                accessLogFile: /dev/stdout
+                enableTracing: false
+                outboundTrafficPolicy:
+                  mode: ALLOW_ANY
+              profile: default
+
+          EOF
+
+          sleep 2
+
+          kubectl wait --timeout=240s --for=jsonpath='{.status.status}'=HEALTHY istiooperator istio-gateway --namespace=istio-system
+
+      - name: Configure DNS in Kubernetes
+        run: |
+          CLUSTER_IP=$(kubectl -n istio-system get svc istio-ingressgateway -o json | jq -r .spec.clusterIP)
+          echo "CLUSTER_IP=${CLUSTER_IP}"
+
+          kubectl apply -f - <<EOF
+          kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: coredns
+            namespace: kube-system
+          data:
+            Corefile: |
+              .:53 {
+                  errors
+                  health {
+                     lameduck 5s
+                  }
+                  rewrite name regex (.*)\.localho\.st istio-ingressgateway.istio-system.svc.cluster.local
+                  hosts {
+                    fallthrough
+                  }
+                  ready
+                  kubernetes cluster.local in-addr.arpa ip6.arpa {
+                     pods insecure
+                     fallthrough in-addr.arpa ip6.arpa
+                     ttl 30
+                  }
+                  prometheus :9153
+                  forward . /etc/resolv.conf {
+                     max_concurrent 1000
+                  }
+                  cache 30
+                  loop
+                  reload
+                  loadbalance
+              }
+          EOF
+
+          kubectl get configmap coredns -n kube-system -o yaml
+
+      # -----------------------------------------------------------------------
+      # Vault — deployed inside Kind as a pod; no host IP routing needed
+      # -----------------------------------------------------------------------
+      - name: Deploy Vault in Kind cluster
+        run: |
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: vault
+            namespace: default
+            labels:
+              app: vault
+          spec:
+            containers:
+              - name: vault
+                image: hashicorp/vault:1.13.3
+                args:
+                  - server
+                  - -dev
+                  - -dev-root-token-id=root
+                  - -dev-listen-address=0.0.0.0:8200
+                ports:
+                  - containerPort: 8200
+                env:
+                  - name: VAULT_DEV_ROOT_TOKEN_ID
+                    value: root
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: vault
+            namespace: default
+          spec:
+            selector:
+              app: vault
+            ports:
+              - port: 8200
+                targetPort: 8200
+          EOF
+
+          kubectl wait --timeout=60s --for=condition=Ready pod/vault
+
+          kubectl create secret generic vault-token \
+            --namespace=default \
+            --from-literal=token=root
+
+      - name: Configure Vault PKI engines for Orderer org
+        run: |
+          kubectl exec vault -- sh -c '
+            export VAULT_ADDR=http://0.0.0.0:8200
+            export VAULT_TOKEN=root
+            VAULT_SVC=http://vault.default.svc.cluster.local:8200
+
+            vault secrets enable -path=pki_orderer pki
+            vault secrets tune -max-lease-ttl=87600h pki_orderer
+
+            # Signing root CA (issuer: signing-ca)
+            vault write pki_orderer/root/generate/internal \
+              common_name="OrdererMSP Signing Root CA" \
+              ttl=87600h issuer_name="signing-ca" \
+              key_type="ec" key_bits=256
+
+            # TLS root CA (issuer: tls-ca)
+            vault write pki_orderer/root/generate/internal \
+              common_name="OrdererMSP TLS Root CA" \
+              ttl=87600h issuer_name="tls-ca" \
+              key_type="ec" key_bits=256
+
+            vault write pki_orderer/config/urls \
+              issuing_certificates="${VAULT_SVC}/v1/pki_orderer/ca" \
+              crl_distribution_points="${VAULT_SVC}/v1/pki_orderer/crl"
+
+            # Sign role (used by orderer node)
+            vault write pki_orderer/roles/orderer-sign \
+              issuer_ref="signing-ca" \
+              allow_subdomains=true allow_any_name=true \
+              max_ttl="87600h" key_type="ec" key_bits=256 \
+              ou="orderer" organization="OrdererMSP"
+
+            # TLS role (used by orderer node)
+            vault write pki_orderer/roles/orderer-tls \
+              issuer_ref="tls-ca" \
+              allow_subdomains=true allow_any_name=true \
+              max_ttl="87600h" key_type="ec" key_bits=256 \
+              ou="orderer" organization="OrdererMSP"
+
+            # Admin sign role (used by identity create)
+            vault write pki_orderer/roles/admin-sign \
+              issuer_ref="signing-ca" \
+              allow_subdomains=true allow_any_name=true \
+              max_ttl="87600h" key_type="ec" key_bits=256 \
+              ou="admin" organization="OrdererMSP"
+          '
+
+      # -----------------------------------------------------------------------
+      # Peer org — FabricCA (credential-store=kubernetes)
+      # -----------------------------------------------------------------------
+      - name: Create Peer org CA (FabricCA)
+        run: |
+          kubectl hlf ca create \
+            --credential-store=kubernetes \
+            --image=$CA_IMAGE --version=$CA_VERSION \
+            --storage-class=standard --capacity=2Gi \
+            --name=org1-ca \
+            --enroll-id=enroll --enroll-pw=enrollpw \
+            --hosts=org1-ca.localho.st
+          kubectl wait --timeout=240s --for=condition=Running fabriccas.hlf.kungfusoftware.es --all
+
+      - name: Register peer identity and create peer (FabricCA)
+        run: |
+          kubectl hlf ca register --name=org1-ca \
+            --user=peer --secret=peerpw --type=peer \
+            --enroll-id enroll --enroll-secret=enrollpw --mspid Org1MSP
+
+          kubectl hlf peer create \
+            --credential-store=kubernetes \
+            --statedb=couchdb \
+            --image=$PEER_IMAGE --version=$PEER_VERSION \
+            --storage-class=standard --enroll-id=peer --mspid=Org1MSP \
+            --enroll-pw=peerpw \
+            --hosts=peer0-org1.localho.st \
+            --capacity=5Gi --name=org1-peer0 \
+            --ca-name=org1-ca.default
+          kubectl wait --timeout=300s --for=condition=Running fabricpeers.hlf.kungfusoftware.es --all
+
+      # -----------------------------------------------------------------------
+      # Orderer org — Vault (credential-store=vault), no FabricCA needed
+      # -----------------------------------------------------------------------
+      - name: Create orderer node (Vault credential store)
+        run: |
+          kubectl hlf ordnode create \
+            --credential-store=vault \
+            --image=$ORDERER_IMAGE --version=$ORDERER_VERSION \
+            --storage-class=standard \
+            --mspid=OrdererMSP \
+            --hosts=orderer0-ord.localho.st \
+            --admin-hosts=admin-orderer0-ord.localho.st \
+            --capacity=2Gi --name=ord-node1 \
+            --vault-address="${VAULT_K8S_ADDR}" \
+            --vault-token-secret=vault-token \
+            --vault-token-secret-namespace=default \
+            --vault-token-secret-key=token \
+            --vault-pki-path=pki_orderer \
+            --vault-role=orderer-sign \
+            --vault-ttl=8760h \
+            --tls-vault-address="${VAULT_K8S_ADDR}" \
+            --tls-vault-token-secret=vault-token \
+            --tls-vault-token-secret-namespace=default \
+            --tls-vault-token-secret-key=token \
+            --tls-vault-pki-path=pki_orderer \
+            --tls-vault-role=orderer-tls \
+            --tls-vault-ttl=8760h
+          kubectl wait --timeout=300s --for=condition=Running fabricorderernodes.hlf.kungfusoftware.es --all
+
+      # -----------------------------------------------------------------------
+      # Channel setup
+      # -----------------------------------------------------------------------
+      - name: Prepare identities and create channel
+        run: |
+          kubectl hlf inspect --output ordservice.yaml -o OrdererMSP
+
+          # Orderer admin identity — issued by Vault PKI
+          kubectl hlf identity create --name ord-admin-sign --namespace default \
+            --mspid OrdererMSP \
+            --credential-store=vault \
+            --vault-address="${VAULT_K8S_ADDR}" \
+            --vault-token-secret=vault-token \
+            --vault-token-secret-namespace=default \
+            --vault-token-secret-key=token \
+            --vault-pki-path=pki_orderer \
+            --vault-role=admin-sign \
+            --vault-ttl=8760h
+
+          # Wait for identity to be provisioned (secret created by controller)
+          kubectl wait --timeout=120s --for=condition=RUNNING fabricidentities.hlf.kungfusoftware.es ord-admin-sign
+
+          # Extract user.yaml from the auto-created secret (same format as ca enroll output)
+          kubectl get secret ord-admin-sign -n default \
+            -o jsonpath='{.data.user\.yaml}' | base64 -d > admin-ordservice.yaml
+          kubectl get secret ord-admin-sign -n default \
+            -o jsonpath='{.data.user\.yaml}' | base64 -d > admin-tls-ordservice.yaml
+          kubectl get secret ord-admin-sign -n default \
+            -o jsonpath='{.data.user\.yaml}' | base64 -d > admin-sign-ordservice.yaml
+
+          kubectl hlf utils adduser --userPath=admin-ordservice.yaml \
+            --config=ordservice.yaml --username=admin --mspid=OrdererMSP
+
+          # Peer admin — enrolled from FabricCA
+          kubectl hlf ca register --name=org1-ca --user=admin --secret=adminpw \
+            --type=admin --enroll-id enroll --enroll-secret=enrollpw --mspid Org1MSP
+          kubectl hlf ca enroll --name=org1-ca --user=admin --secret=adminpw \
+            --mspid Org1MSP --ca-name ca --output peer-org1.yaml
+          kubectl hlf inspect --output org1.yaml -o Org1MSP -o OrdererMSP
+          kubectl hlf utils adduser --userPath=peer-org1.yaml \
+            --config=org1.yaml --username=admin --mspid=Org1MSP
+
+          kubectl create secret generic wallet --namespace=default \
+            --from-file=peer-org1.yaml=$PWD/peer-org1.yaml \
+            --from-file=admin-sign-ordservice.yaml=$PWD/admin-sign-ordservice.yaml \
+            --from-file=admin-tls-ordservice.yaml=$PWD/admin-tls-ordservice.yaml
+
+          export IDENT_8=$(printf "%8s" "")
+          export ORDERER0_TLS_CERT=$(kubectl get fabricorderernodes ord-node1 \
+            -o=jsonpath='{.status.tlsCert}' | sed -e "s/^/${IDENT_8}/")
+
+          kubectl apply -f - <<EOF
+          apiVersion: hlf.kungfusoftware.es/v1alpha1
+          kind: FabricMainChannel
+          metadata:
+            name: demo
+          spec:
+            name: demo
+            adminOrdererOrganizations:
+              - mspID: OrdererMSP
+            adminPeerOrganizations:
+              - mspID: Org1MSP
+            channelConfig:
+              application:
+                acls: null
+                capabilities:
+                  - V2_0
+                  - V2_5
+                policies: null
+              capabilities:
+                - V2_0
+              orderer:
+                batchSize:
+                  absoluteMaxBytes: 1048576
+                  maxMessageCount: 10
+                  preferredMaxBytes: 524288
+                batchTimeout: 2s
+                capabilities:
+                  - V2_0
+                etcdRaft:
+                  options:
+                    electionTick: 10
+                    heartbeatTick: 1
+                    maxInflightBlocks: 5
+                    snapshotIntervalSize: 16777216
+                    tickInterval: 500ms
+                ordererType: etcdraft
+                policies: null
+                state: STATE_NORMAL
+              policies: null
+            externalOrdererOrganizations: []
+            externalPeerOrganizations: []
+            peerOrganizations:
+              - mspID: Org1MSP
+                caName: "org1-ca"
+                caNamespace: "default"
+            identities:
+              OrdererMSP:
+                secretKey: admin-tls-ordservice.yaml
+                secretName: wallet
+                secretNamespace: default
+              OrdererMSP-tls:
+                secretKey: admin-tls-ordservice.yaml
+                secretName: wallet
+                secretNamespace: default
+              OrdererMSP-sign:
+                secretKey: admin-sign-ordservice.yaml
+                secretName: wallet
+                secretNamespace: default
+              Org1MSP:
+                secretKey: peer-org1.yaml
+                secretName: wallet
+                secretNamespace: default
+            ordererOrganizations:
+              - externalOrderersToJoin: []
+                mspID: OrdererMSP
+                ordererEndpoints:
+                  - orderer0-ord.localho.st:443
+                orderersToJoin:
+                  - name: ord-node1
+                    namespace: default
+            orderers:
+              - host: orderer0-ord.localho.st
+                port: 443
+                tlsCert: |-
+          ${ORDERER0_TLS_CERT}
+          EOF
+
+          kubectl wait --timeout=240s --for=condition=RUNNING fabricmainchannels.hlf.kungfusoftware.es --all
+
+      - name: Join peer to channel
+        run: |
+          kubectl get fabricorderernodes ord-node1 -o jsonpath='{.status.tlsCert}' > ./orderer-cert.pem
+          kubectl hlf channelcrd follower create \
+            --channel-name=demo \
+            --mspid=Org1MSP \
+            --name="demo-org1msp" \
+            --orderer-certificates="./orderer-cert.pem" \
+            --orderer-urls="grpcs://orderer0-ord.localho.st:443" \
+            --anchor-peers="org1-peer0:7051" \
+            --peers="org1-peer0.default" \
+            --secret-name=wallet \
+            --secret-ns=default \
+            --secret-key="peer-org1.yaml"
+          kubectl wait --timeout=240s --for=condition=RUNNING fabricfollowerchannels.hlf.kungfusoftware.es --all
+
+      # -----------------------------------------------------------------------
+      # Chaincode
+      # -----------------------------------------------------------------------
+      - name: Install, approve, commit and test chaincode
+        run: |
+          export CHAINCODE_NAME=asset
+          export CHAINCODE_LABEL=asset
+          cat > metadata.json <<'EOF'
+          {"type": "ccaas", "label": "asset"}
+          EOF
+          cat > connection.json <<'EOF'
+          {"address": "asset:7052", "dial_timeout": "10s", "tls_required": false}
+          EOF
+          tar cfz code.tar.gz connection.json
+          tar cfz asset-transfer-basic-external.tgz metadata.json code.tar.gz
+
+          export PACKAGE_ID=$(kubectl hlf chaincode calculatepackageid \
+            --path=asset-transfer-basic-external.tgz --language=node --label=$CHAINCODE_LABEL)
+
+          kubectl hlf chaincode install --path=./asset-transfer-basic-external.tgz \
+            --config=org1.yaml --language=golang --label=$CHAINCODE_LABEL \
+            --user=admin --peer=org1-peer0.default
+
+          kubectl hlf externalchaincode sync \
+            --image=kfsoftware/chaincode-external:latest \
+            --name=$CHAINCODE_NAME \
+            --namespace=default \
+            --package-id=$PACKAGE_ID \
+            --tls-required=false \
+            --replicas=1
+
+          kubectl hlf chaincode approveformyorg \
+            --config=org1.yaml --user=admin --peer=org1-peer0.default \
+            --package-id=$PACKAGE_ID \
+            --version "1.0" --sequence 1 --name=asset \
+            --policy="OR('Org1MSP.member')" --channel=demo
+
+          kubectl hlf chaincode commit \
+            --config=org1.yaml --user=admin --mspid=Org1MSP \
+            --version "1.0" --sequence 1 --name=asset \
+            --policy="OR('Org1MSP.member')" --channel=demo
+
+          kubectl wait --timeout=240s --for=condition=Available deployment asset --namespace=default
+
+          kubectl hlf chaincode invoke --config=org1.yaml \
+            --user=admin --peer=org1-peer0.default \
+            --chaincode=asset --channel=demo \
+            --fcn=initLedger -a '[]'
+
+          kubectl hlf chaincode query --config=org1.yaml \
+            --user=admin --peer=org1-peer0.default \
+            --chaincode=asset --channel=demo \
+            --fcn=GetAllAssets -a '[]'
+
+      # -----------------------------------------------------------------------
+      # Reenroll: peer via FabricCA, orderer via Vault
+      # -----------------------------------------------------------------------
+      - name: Reenroll peer certificate (FabricCA)
+        run: |
+          kubectl hlf peer renew --name=org1-peer0 --namespace=default
+          kubectl wait --timeout=300s --for=condition=Running fabricpeers.hlf.kungfusoftware.es --all
+
+      - name: Reenroll orderer certificate (Vault)
+        run: |
+          kubectl hlf ordnode renew --name=ord-node1 --namespace=default
+          kubectl wait --timeout=300s --for=condition=Running fabricorderernodes.hlf.kungfusoftware.es --all
+
+      - name: Verify channel still operational after mixed reenroll
+        run: |
+          sleep 15
+          kubectl hlf chaincode query --config=org1.yaml \
+            --user=admin --peer=org1-peer0.default \
+            --chaincode=asset --channel=demo \
+            --fcn=GetAllAssets -a '[]'
+
+      # -----------------------------------------------------------------------
+      # Debug info on failure
+      # -----------------------------------------------------------------------
+      - name: Show debug info on failure
+        if: failure()
+        run: |
+          kubectl get nodes -o=wide
+          kubectl get pods -o=wide -A
+          kubectl get service -o=wide -A
+          kubectl get crds
+          kubectl get fabricpeers.hlf.kungfusoftware.es -A \
+            -o=custom-columns='NAME:metadata.name,NAMESPACE:metadata.namespace,STATE:status.status,MESSAGE:status.message'
+          kubectl get fabricorderernodes.hlf.kungfusoftware.es -A \
+            -o=custom-columns='NAME:metadata.name,NAMESPACE:metadata.namespace,STATE:status.status,MESSAGE:status.message'
+          kubectl get fabriccas.hlf.kungfusoftware.es -A \
+            -o=custom-columns='NAME:metadata.name,NAMESPACE:metadata.namespace,STATE:status.status,MESSAGE:status.message'
+          kubectl get fabricmainchannels.hlf.kungfusoftware.es -A \
+            -o=custom-columns='NAME:metadata.name,NAMESPACE:metadata.namespace,STATE:status.status,MESSAGE:status.message'
+          kubectl get fabricfollowerchannels.hlf.kungfusoftware.es -A \
+            -o=custom-columns='NAME:metadata.name,NAMESPACE:metadata.namespace,STATE:status.status,MESSAGE:status.message'
+          kubectl get configmap coredns -n kube-system -o yaml
+          echo "--- hlf-operator logs ---"
+          kubectl describe deployment hlf-operator-controller-manager
+          kubectl logs -l app.kubernetes.io/name=hlf-operator -c manager --tail 2500
+          kubectl get fabricmainchannels -o yaml
+          kubectl get fabricfollowerchannels -o yaml
+          POD=$(kubectl get pod -l 'release in (org1-peer0)' -o jsonpath="{.items[0].metadata.name}")
+          kubectl logs $POD -c peer
+          POD=$(kubectl get pod -l 'release in (ord-node1)' -o jsonpath="{.items[0].metadata.name}")
+          kubectl logs $POD
+          echo "--- Vault status ---"
+          vault status || true
+          vault secrets list || true

--- a/controllers/certs/provision_certs.go
+++ b/controllers/certs/provision_certs.go
@@ -1,3 +1,23 @@
+// Package certs provides PKI operations using Fabric CA.
+//
+// Deprecated: This package is deprecated and will be removed in a future version.
+// Use the github.com/kfsoftware/hlf-operator/pkg/pki package instead.
+// The new PKI package provides a unified interface for both Fabric CA and HashiCorp Vault.
+//
+// Migration guide:
+//
+//	Old code:
+//	  crt, key, rootCrt, err := certs.EnrollUser(certs.EnrollUserRequest{...})
+//
+//	New code:
+//	  import "github.com/kfsoftware/hlf-operator/pkg/pki"
+//	  import _ "github.com/kfsoftware/hlf-operator/pkg/pki/fabricca"
+//
+//	  provider, _ := pki.NewProvider(&pki.ProviderConfig{
+//	      Type: pki.ProviderTypeFabricCA,
+//	      FabricCA: &pki.FabricCAConfig{...},
+//	  })
+//	  resp, err := provider.Enroll(ctx, pki.EnrollRequest{...})
 package certs
 
 import (

--- a/controllers/certs_vault/provision_certs.go
+++ b/controllers/certs_vault/provision_certs.go
@@ -1,3 +1,24 @@
+// Package certs_vault provides PKI operations using HashiCorp Vault.
+//
+// Deprecated: This package is deprecated and will be removed in a future version.
+// Use the github.com/kfsoftware/hlf-operator/pkg/pki package instead.
+// The new PKI package provides a unified interface for both Fabric CA and HashiCorp Vault.
+//
+// Migration guide:
+//
+//	Old code:
+//	  crt, key, rootCrt, err := certs_vault.EnrollUser(clientSet, vaultConf, request, params)
+//
+//	New code:
+//	  import "github.com/kfsoftware/hlf-operator/pkg/pki"
+//	  import _ "github.com/kfsoftware/hlf-operator/pkg/pki/vault"
+//
+//	  provider, _ := pki.NewProvider(&pki.ProviderConfig{
+//	      Type:      pki.ProviderTypeVault,
+//	      ClientSet: clientSet,
+//	      Vault:     &pki.VaultConfig{...},
+//	  })
+//	  resp, err := provider.Enroll(ctx, pki.EnrollRequest{...})
 package certs_vault
 
 import (

--- a/controllers/identity/identity_pki.go
+++ b/controllers/identity/identity_pki.go
@@ -1,0 +1,213 @@
+package identity
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+
+	hlfv1alpha1 "github.com/kfsoftware/hlf-operator/pkg/apis/hlf.kungfusoftware.es/v1alpha1"
+	"github.com/kfsoftware/hlf-operator/pkg/pki"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// pkiHelper provides PKI operations for the identity controller using the unified PKI interface
+type pkiHelper struct {
+	clientSet kubernetes.Interface
+}
+
+// newPKIHelper creates a new PKI helper
+func newPKIHelper(clientSet kubernetes.Interface) *pkiHelper {
+	return &pkiHelper{clientSet: clientSet}
+}
+
+// createProvider creates the appropriate PKI provider based on credential store configuration
+func (h *pkiHelper) createProvider(ctx context.Context, conf *hlfv1alpha1.FabricIdentity) (pki.Provider, error) {
+	switch conf.Spec.CredentialStore {
+	case hlfv1alpha1.CredentialStoreVault:
+		return h.createVaultProvider(ctx, conf)
+	default:
+		return h.createFabricCAProvider(ctx, conf)
+	}
+}
+
+// createFabricCAProvider creates a FabricCA PKI provider from identity config
+func (h *pkiHelper) createFabricCAProvider(ctx context.Context, conf *hlfv1alpha1.FabricIdentity) (pki.Provider, error) {
+	cacert, err := h.getCertBytesFromCATLS(conf.Spec.Catls)
+	if err != nil {
+		return nil, err
+	}
+
+	caURL := fmt.Sprintf("https://%s:%d", conf.Spec.Cahost, conf.Spec.Caport)
+
+	return pki.NewProvider(&pki.ProviderConfig{
+		Type:      pki.ProviderTypeFabricCA,
+		ClientSet: h.clientSet,
+		FabricCA: &pki.FabricCAConfig{
+			URL:     caURL,
+			CAName:  conf.Spec.Caname,
+			TLSCert: string(cacert),
+			MSPID:   conf.Spec.MSPID,
+		},
+	})
+}
+
+// createVaultProvider creates a Vault PKI provider from identity config
+func (h *pkiHelper) createVaultProvider(ctx context.Context, conf *hlfv1alpha1.FabricIdentity) (pki.Provider, error) {
+	if conf.Spec.Vault == nil {
+		return nil, errors.New("vault configuration is required for vault credential store")
+	}
+
+	vaultConf := &conf.Spec.Vault.Vault
+	vaultReq := &conf.Spec.Vault.Request
+
+	return pki.NewProvider(&pki.ProviderConfig{
+		Type:      pki.ProviderTypeVault,
+		ClientSet: h.clientSet,
+		Vault: &pki.VaultConfig{
+			URL:     vaultConf.URL,
+			PKIPath: vaultReq.PKI,
+			Role:    vaultReq.Role,
+			TTL:     vaultReq.TTL,
+			Auth: pki.VaultAuthConfig{
+				TokenSecretRef: convertSecretRef(vaultConf.TokenSecretRef),
+			},
+			TLS: pki.VaultTLSConfig{
+				CACert:             vaultConf.CACert,
+				ClientCert:         vaultConf.ClientCert,
+				ClientKeySecretRef: convertSecretRef(vaultConf.ClientKeySecretRef),
+				ServerName:         vaultConf.ServerName,
+				SkipVerify:         vaultConf.TLSSkipVerify,
+			},
+		},
+	})
+}
+
+// CreateSignCryptoMaterialV2 creates sign crypto material using the PKI interface
+func (h *pkiHelper) CreateSignCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricIdentity,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	resp, err := provider.Enroll(ctx, pki.EnrollRequest{
+		User:    conf.Spec.Enrollid,
+		Secret:  conf.Spec.Enrollsecret,
+		CN:      conf.Name,
+		Hosts:   []string{},
+		MSPID:   conf.Spec.MSPID,
+		Profile: "",
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to enroll identity")
+	}
+
+	return resp.Certificate, resp.PrivateKey, resp.RootCertificate, nil
+}
+
+// ReenrollSignCryptoMaterialV2 re-enrolls sign crypto material using the PKI interface
+func (h *pkiHelper) ReenrollSignCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricIdentity,
+	existingCert string,
+	existingKey *ecdsa.PrivateKey,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	resp, err := provider.Reenroll(ctx, pki.ReenrollRequest{
+		EnrollID:     conf.Spec.Enrollid,
+		CN:           conf.Name,
+		Hosts:        []string{},
+		MSPID:        conf.Spec.MSPID,
+		Profile:      "",
+		ExistingCert: existingCert,
+		ExistingKey:  existingKey,
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to re-enroll identity")
+	}
+
+	return resp.Certificate, existingKey, resp.RootCertificate, nil
+}
+
+// RegisterUserV2 registers a user using the PKI interface
+func (h *pkiHelper) RegisterUserV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricIdentity,
+	attributes []pki.Attribute,
+) (string, error) {
+	provider, err := h.createProvider(ctx, conf)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	// Check if provider supports registration
+	if supporter, ok := provider.(pki.RegistrationSupporter); ok {
+		if !supporter.SupportsRegistration() {
+			return "", errors.Errorf("provider %s does not support identity registration", provider.Type())
+		}
+	}
+
+	resp, err := provider.Register(ctx, pki.RegisterRequest{
+		EnrollID:     conf.Spec.Register.Enrollid,
+		EnrollSecret: conf.Spec.Register.Enrollsecret,
+		User:         conf.Spec.Enrollid,
+		Secret:       conf.Spec.Enrollsecret,
+		Type:         conf.Spec.Register.Type,
+		MSPID:        conf.Spec.MSPID,
+		Attributes:   attributes,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to register identity")
+	}
+
+	return resp.Secret, nil
+}
+
+// getCertBytesFromCATLS retrieves the CA TLS certificate bytes
+func (h *pkiHelper) getCertBytesFromCATLS(caTls *hlfv1alpha1.Catls) ([]byte, error) {
+	var certBytes []byte
+	var err error
+
+	if caTls.Cacert != "" {
+		certBytes, err = base64.StdEncoding.DecodeString(caTls.Cacert)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode CA cert from base64")
+		}
+	} else if caTls.SecretRef != nil {
+		secret, err := h.clientSet.CoreV1().Secrets(caTls.SecretRef.Namespace).Get(
+			context.Background(),
+			caTls.SecretRef.Name,
+			v1.GetOptions{},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get CA cert secret")
+		}
+		certBytes = secret.Data[caTls.SecretRef.Key]
+	} else {
+		return nil, errors.New("invalid CA TLS configuration: neither cacert nor secretRef provided")
+	}
+
+	return certBytes, nil
+}
+
+// convertSecretRef converts from hlfv1alpha1.VaultSecretRef to pki.SecretRef
+func convertSecretRef(ref *hlfv1alpha1.VaultSecretRef) *pki.SecretRef {
+	if ref == nil {
+		return nil
+	}
+	return &pki.SecretRef{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+		Key:       ref.Key,
+	}
+}

--- a/controllers/ordnode/ordnode_controller.go
+++ b/controllers/ordnode/ordnode_controller.go
@@ -43,6 +43,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	// Register PKI providers
+	_ "github.com/kfsoftware/hlf-operator/pkg/pki/fabricca"
+	_ "github.com/kfsoftware/hlf-operator/pkg/pki/vault"
 )
 
 // FabricOrdererNodeReconciler reconciles a FabricOrdererNode object
@@ -1114,6 +1118,10 @@ func getConfig(
 	var tlsKey, adminKey, signKey *ecdsa.PrivateKey
 	var err error
 	ctx := context.Background()
+
+	// Create PKI helper for certificate operations
+	pki := newPKIHelper(client)
+
 	if tlsParams.External != nil {
 		secret, err := client.CoreV1().Secrets(tlsParams.External.SecretNamespace).Get(ctx, tlsParams.External.SecretName, v1.GetOptions{})
 		if err != nil {
@@ -1136,8 +1144,8 @@ func getConfig(
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get existing tls crypto material")
 		}
-		tlsCert, tlsKey, tlsRootCert, err = ReenrollTLSCryptoMaterial(
-			client,
+		tlsCert, tlsKey, tlsRootCert, err = pki.ReenrollTLSCryptoMaterialV2(
+			ctx,
 			conf,
 			&tlsParams,
 			string(utils.EncodeX509Certificate(tlsCert)),
@@ -1151,8 +1159,8 @@ func getConfig(
 		tlsCert, tlsKey, tlsRootCert, err = getExistingTLSCrypto(client, chartName, namespace)
 		if err != nil {
 			log.Warnf("Failed to get existing tls crypto material for %s, will create new one", chartName)
-			tlsCert, tlsKey, tlsRootCert, err = CreateTLSCryptoMaterial(
-				client,
+			tlsCert, tlsKey, tlsRootCert, err = pki.CreateTLSCryptoMaterialV2(
+				ctx,
 				conf,
 				&tlsParams,
 			)
@@ -1166,8 +1174,8 @@ func getConfig(
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get existing tls admin crypto material")
 		}
-		adminCert, adminKey, adminRootCert, adminClientRootCert, err = ReenrollTLSAdminCryptoMaterial(
-			client,
+		adminCert, adminKey, adminRootCert, adminClientRootCert, err = pki.ReenrollTLSAdminCryptoMaterialV2(
+			ctx,
 			conf,
 			&tlsParams,
 			string(utils.EncodeX509Certificate(adminCert)),
@@ -1180,8 +1188,8 @@ func getConfig(
 		adminCert, adminKey, adminRootCert, adminClientRootCert, err = getExistingTLSAdminCrypto(client, chartName, namespace)
 		if err != nil {
 			log.Warnf("Failed to get existing tls admin crypto material, creating new one")
-			adminCert, adminKey, adminRootCert, adminClientRootCert, err = CreateTLSAdminCryptoMaterial(
-				client,
+			adminCert, adminKey, adminRootCert, adminClientRootCert, err = pki.CreateTLSAdminCryptoMaterialV2(
+				ctx,
 				conf,
 				&tlsParams,
 			)
@@ -1214,8 +1222,8 @@ func getConfig(
 			return nil, errors.Wrapf(err, "failed to get existing sign crypto material")
 		}
 		signCertPem := utils.EncodeX509Certificate(signCert)
-		signCert, signKey, signRootCert, err = ReenrollSignCryptoMaterial(
-			client,
+		signCert, signKey, signRootCert, err = pki.ReenrollSignCryptoMaterialV2(
+			ctx,
 			conf,
 			&signParams,
 			string(signCertPem),
@@ -1230,8 +1238,8 @@ func getConfig(
 		if err != nil {
 			log.Warnf("Failed to get existing sign crypto material: %s", err)
 
-			signCert, signKey, signRootCert, err = CreateSignCryptoMaterial(
-				client,
+			signCert, signKey, signRootCert, err = pki.CreateSignCryptoMaterialV2(
+				ctx,
 				conf,
 				&signParams,
 			)

--- a/controllers/ordnode/ordnode_pki.go
+++ b/controllers/ordnode/ordnode_pki.go
@@ -1,0 +1,349 @@
+package ordnode
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+
+	hlfv1alpha1 "github.com/kfsoftware/hlf-operator/pkg/apis/hlf.kungfusoftware.es/v1alpha1"
+	"github.com/kfsoftware/hlf-operator/pkg/pki"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// pkiHelper provides PKI operations for the orderer node controller using the unified PKI interface
+type pkiHelper struct {
+	clientSet kubernetes.Interface
+}
+
+// newPKIHelper creates a new PKI helper
+func newPKIHelper(clientSet kubernetes.Interface) *pkiHelper {
+	return &pkiHelper{clientSet: clientSet}
+}
+
+// createProvider creates the appropriate PKI provider based on credential store configuration
+func (h *pkiHelper) createProvider(ctx context.Context, conf *hlfv1alpha1.FabricOrdererNode, enrollment interface{}) (pki.Provider, error) {
+	switch conf.Spec.CredentialStore {
+	case hlfv1alpha1.CredentialStoreVault:
+		return h.createVaultProvider(ctx, enrollment)
+	default:
+		return h.createFabricCAProvider(ctx, enrollment)
+	}
+}
+
+// createFabricCAProvider creates a FabricCA PKI provider from enrollment config
+func (h *pkiHelper) createFabricCAProvider(ctx context.Context, enrollment interface{}) (pki.Provider, error) {
+	var caURL, caName, tlsCert, mspID string
+
+	switch e := enrollment.(type) {
+	case *hlfv1alpha1.Component:
+		cacert, err := h.getCertBytesFromCATLS(e.Catls)
+		if err != nil {
+			return nil, err
+		}
+		caURL = fmt.Sprintf("https://%s:%d", e.Cahost, e.Caport)
+		caName = e.Caname
+		tlsCert = string(cacert)
+	case *hlfv1alpha1.TLSComponent:
+		cacert, err := h.getCertBytesFromCATLS(e.Catls)
+		if err != nil {
+			return nil, err
+		}
+		caURL = fmt.Sprintf("https://%s:%d", e.Cahost, e.Caport)
+		caName = e.Caname
+		tlsCert = string(cacert)
+	default:
+		return nil, errors.New("unsupported enrollment type")
+	}
+
+	return pki.NewProvider(&pki.ProviderConfig{
+		Type:      pki.ProviderTypeFabricCA,
+		ClientSet: h.clientSet,
+		FabricCA: &pki.FabricCAConfig{
+			URL:     caURL,
+			CAName:  caName,
+			TLSCert: tlsCert,
+			MSPID:   mspID,
+		},
+	})
+}
+
+// createVaultProvider creates a Vault PKI provider from enrollment config
+func (h *pkiHelper) createVaultProvider(ctx context.Context, enrollment interface{}) (pki.Provider, error) {
+	var vaultConf *hlfv1alpha1.VaultSpecConf
+	var vaultReq *hlfv1alpha1.VaultPKICertificateRequest
+
+	switch e := enrollment.(type) {
+	case *hlfv1alpha1.Component:
+		if e.Vault == nil {
+			return nil, errors.New("vault configuration is required for vault credential store")
+		}
+		vaultConf = &e.Vault.Vault
+		vaultReq = &e.Vault.Request
+	case *hlfv1alpha1.TLSComponent:
+		if e.Vault == nil {
+			return nil, errors.New("vault configuration is required for vault credential store")
+		}
+		vaultConf = &e.Vault.Vault
+		vaultReq = &e.Vault.Request
+	default:
+		return nil, errors.New("unsupported enrollment type")
+	}
+
+	return pki.NewProvider(&pki.ProviderConfig{
+		Type:      pki.ProviderTypeVault,
+		ClientSet: h.clientSet,
+		Vault: &pki.VaultConfig{
+			URL:     vaultConf.URL,
+			PKIPath: vaultReq.PKI,
+			Role:    vaultReq.Role,
+			TTL:     vaultReq.TTL,
+			Auth: pki.VaultAuthConfig{
+				TokenSecretRef: convertSecretRef(vaultConf.TokenSecretRef),
+			},
+			TLS: pki.VaultTLSConfig{
+				CACert:             vaultConf.CACert,
+				ClientCert:         vaultConf.ClientCert,
+				ClientKeySecretRef: convertSecretRef(vaultConf.ClientKeySecretRef),
+				ServerName:         vaultConf.ServerName,
+				SkipVerify:         vaultConf.TLSSkipVerify,
+			},
+		},
+	})
+}
+
+// getTLSHosts returns all TLS hosts for the orderer node
+func getTLSHostsForOrderer(conf *hlfv1alpha1.FabricOrdererNode, enrollment *hlfv1alpha1.TLSComponent) []string {
+	var hosts []string
+	hosts = append(hosts, enrollment.Csr.Hosts...)
+
+	if conf.Spec.Istio != nil {
+		hosts = append(hosts, conf.Spec.Istio.Hosts...)
+	}
+	if conf.Spec.Traefik != nil {
+		hosts = append(hosts, conf.Spec.Traefik.Hosts...)
+	}
+	if conf.Spec.AdminIstio != nil {
+		hosts = append(hosts, conf.Spec.AdminIstio.Hosts...)
+	}
+	if conf.Spec.AdminTraefik != nil {
+		hosts = append(hosts, conf.Spec.AdminTraefik.Hosts...)
+	}
+
+	return hosts
+}
+
+// CreateTLSCryptoMaterialV2 creates TLS crypto material using the PKI interface
+func (h *pkiHelper) CreateTLSCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricOrdererNode,
+	enrollment *hlfv1alpha1.TLSComponent,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	hosts := getTLSHostsForOrderer(conf, enrollment)
+
+	resp, err := provider.Enroll(ctx, pki.EnrollRequest{
+		User:    enrollment.Enrollid,
+		Secret:  enrollment.Enrollsecret,
+		CN:      enrollment.Enrollid,
+		Hosts:   hosts,
+		MSPID:   conf.Spec.MspID,
+		Profile: "tls",
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to enroll TLS")
+	}
+
+	return resp.Certificate, resp.PrivateKey, resp.RootCertificate, nil
+}
+
+// CreateTLSAdminCryptoMaterialV2 creates TLS admin crypto material using the PKI interface
+func (h *pkiHelper) CreateTLSAdminCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricOrdererNode,
+	enrollment *hlfv1alpha1.TLSComponent,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	hosts := getTLSHostsForOrderer(conf, enrollment)
+
+	resp, err := provider.Enroll(ctx, pki.EnrollRequest{
+		User:    enrollment.Enrollid,
+		Secret:  enrollment.Enrollsecret,
+		CN:      enrollment.Enrollid,
+		Hosts:   hosts,
+		MSPID:   conf.Spec.MspID,
+		Profile: "tls",
+	})
+	if err != nil {
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to enroll TLS admin")
+	}
+
+	// Return root cert twice for admin (client root cert is same as TLS root cert)
+	return resp.Certificate, resp.PrivateKey, resp.RootCertificate, resp.RootCertificate, nil
+}
+
+// CreateSignCryptoMaterialV2 creates sign crypto material using the PKI interface
+func (h *pkiHelper) CreateSignCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricOrdererNode,
+	enrollment *hlfv1alpha1.Component,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	resp, err := provider.Enroll(ctx, pki.EnrollRequest{
+		User:   enrollment.Enrollid,
+		Secret: enrollment.Enrollsecret,
+		CN:     conf.Name,
+		Hosts:  []string{},
+		MSPID:  conf.Spec.MspID,
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to enroll sign")
+	}
+
+	return resp.Certificate, resp.PrivateKey, resp.RootCertificate, nil
+}
+
+// ReenrollTLSCryptoMaterialV2 re-enrolls TLS crypto material using the PKI interface
+func (h *pkiHelper) ReenrollTLSCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricOrdererNode,
+	enrollment *hlfv1alpha1.TLSComponent,
+	existingCert string,
+	existingKey *ecdsa.PrivateKey,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	hosts := getTLSHostsForOrderer(conf, enrollment)
+
+	resp, err := provider.Reenroll(ctx, pki.ReenrollRequest{
+		EnrollID:     enrollment.Enrollid,
+		CN:           conf.Name,
+		Hosts:        hosts,
+		MSPID:        conf.Spec.MspID,
+		Profile:      "tls",
+		ExistingCert: existingCert,
+		ExistingKey:  existingKey,
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to re-enroll TLS")
+	}
+
+	return resp.Certificate, existingKey, resp.RootCertificate, nil
+}
+
+// ReenrollTLSAdminCryptoMaterialV2 re-enrolls TLS admin crypto material using the PKI interface
+func (h *pkiHelper) ReenrollTLSAdminCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricOrdererNode,
+	enrollment *hlfv1alpha1.TLSComponent,
+	existingCert string,
+	existingKey *ecdsa.PrivateKey,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	hosts := getTLSHostsForOrderer(conf, enrollment)
+
+	resp, err := provider.Reenroll(ctx, pki.ReenrollRequest{
+		EnrollID:     enrollment.Enrollid,
+		CN:           conf.Name,
+		Hosts:        hosts,
+		MSPID:        conf.Spec.MspID,
+		Profile:      "tls",
+		ExistingCert: existingCert,
+		ExistingKey:  existingKey,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to re-enroll TLS admin")
+	}
+
+	// Return root cert twice for admin
+	return resp.Certificate, existingKey, resp.RootCertificate, resp.RootCertificate, nil
+}
+
+// ReenrollSignCryptoMaterialV2 re-enrolls sign crypto material using the PKI interface
+func (h *pkiHelper) ReenrollSignCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricOrdererNode,
+	enrollment *hlfv1alpha1.Component,
+	existingCert string,
+	existingKey *ecdsa.PrivateKey,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	resp, err := provider.Reenroll(ctx, pki.ReenrollRequest{
+		EnrollID:     enrollment.Enrollid,
+		CN:           "",
+		Hosts:        []string{},
+		MSPID:        conf.Spec.MspID,
+		ExistingCert: existingCert,
+		ExistingKey:  existingKey,
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to re-enroll sign")
+	}
+
+	return resp.Certificate, existingKey, resp.RootCertificate, nil
+}
+
+// getCertBytesFromCATLS retrieves the CA TLS certificate bytes
+func (h *pkiHelper) getCertBytesFromCATLS(caTls *hlfv1alpha1.Catls) ([]byte, error) {
+	var certBytes []byte
+	var err error
+
+	if caTls.Cacert != "" {
+		certBytes, err = base64.StdEncoding.DecodeString(caTls.Cacert)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode CA cert from base64")
+		}
+	} else if caTls.SecretRef != nil {
+		secret, err := h.clientSet.CoreV1().Secrets(caTls.SecretRef.Namespace).Get(
+			context.Background(),
+			caTls.SecretRef.Name,
+			v1.GetOptions{},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get CA cert secret")
+		}
+		certBytes = secret.Data[caTls.SecretRef.Key]
+	} else {
+		return nil, errors.New("invalid CA TLS configuration: neither cacert nor secretRef provided")
+	}
+
+	return certBytes, nil
+}
+
+// convertSecretRef converts from hlfv1alpha1.VaultSecretRef to pki.SecretRef
+func convertSecretRef(ref *hlfv1alpha1.VaultSecretRef) *pki.SecretRef {
+	if ref == nil {
+		return nil
+	}
+	return &pki.SecretRef{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+		Key:       ref.Key,
+	}
+}

--- a/controllers/peer/peer_controller.go
+++ b/controllers/peer/peer_controller.go
@@ -50,6 +50,10 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	// Register PKI providers
+	_ "github.com/kfsoftware/hlf-operator/pkg/pki/fabricca"
+	_ "github.com/kfsoftware/hlf-operator/pkg/pki/vault"
 )
 
 // FabricPeerReconciler reconciles a FabricPeer object
@@ -1351,6 +1355,10 @@ func GetConfig(
 	var tlsKey, tlsOpsKey, signKey *ecdsa.PrivateKey
 	var err error
 	ctx := context.Background()
+
+	// Create PKI helper for certificate operations
+	pki := newPKIHelper(client)
+
 	if tlsParams.External != nil {
 		secret, err := client.CoreV1().Secrets(tlsParams.External.SecretNamespace).Get(ctx, tlsParams.External.SecretName, v1.GetOptions{})
 		if err != nil {
@@ -1375,8 +1383,8 @@ func GetConfig(
 		}
 		if tlsCert.NotAfter.Before(time.Now()) {
 			log.Infof("Enrolling tls crypto material for %s", chartName)
-			tlsCert, tlsKey, tlsRootCert, err = CreateTLSCryptoMaterial(
-				client,
+			tlsCert, tlsKey, tlsRootCert, err = pki.CreateTLSCryptoMaterialV2(
+				ctx,
 				conf,
 				&conf.Spec.Secret.Enrollment.TLS,
 			)
@@ -1386,9 +1394,9 @@ func GetConfig(
 			log.Infof("Successfully enrolled tls crypto material for %s", chartName)
 		} else {
 			if renewCertificatesReenroll {
-				tlsCert, tlsKey, tlsRootCert, err = ReenrollTLSCryptoMaterial(
+				tlsCert, tlsKey, tlsRootCert, err = pki.ReenrollTLSCryptoMaterialV2(
+					ctx,
 					conf,
-					client,
 					&tlsParams,
 					string(utils.EncodeX509Certificate(tlsCert)),
 					tlsKey,
@@ -1404,8 +1412,8 @@ func GetConfig(
 				if authenticationFailure {
 					log.Infof("Re enroll failed because of credentials, falling back to enroll")
 					// just enroll the user
-					tlsCert, tlsKey, tlsRootCert, err = CreateTLSCryptoMaterial(
-						client,
+					tlsCert, tlsKey, tlsRootCert, err = pki.CreateTLSCryptoMaterialV2(
+						ctx,
 						conf,
 						&tlsParams,
 					)
@@ -1416,8 +1424,8 @@ func GetConfig(
 				log.Infof("Successfully reenrolled tls crypto material for %s", chartName)
 			} else {
 				log.Infof("Enrolling new tls crypto material for %s (reenroll disabled)", chartName)
-				tlsCert, tlsKey, tlsRootCert, err = CreateTLSCryptoMaterial(
-					client,
+				tlsCert, tlsKey, tlsRootCert, err = pki.CreateTLSCryptoMaterialV2(
+					ctx,
 					conf,
 					&tlsParams,
 				)
@@ -1431,8 +1439,8 @@ func GetConfig(
 	} else {
 		tlsCert, tlsKey, tlsRootCert, err = getExistingTLSCrypto(client, chartName, namespace)
 		if err != nil {
-			tlsCert, tlsKey, tlsRootCert, err = CreateTLSCryptoMaterial(
-				client,
+			tlsCert, tlsKey, tlsRootCert, err = pki.CreateTLSCryptoMaterialV2(
+				ctx,
 				conf,
 				&tlsParams,
 			)
@@ -1442,8 +1450,8 @@ func GetConfig(
 		}
 	}
 	if refreshCerts {
-		tlsOpsCert, tlsOpsKey, _, err = CreateTLSOPSCryptoMaterial(
-			client,
+		tlsOpsCert, tlsOpsKey, _, err = pki.CreateTLSCryptoMaterialV2(
+			ctx,
 			conf,
 			&tlsParams,
 		)
@@ -1453,8 +1461,8 @@ func GetConfig(
 	} else {
 		tlsOpsCert, tlsOpsKey, _, err = getExistingTLSOPSCrypto(client, chartName, namespace)
 		if err != nil {
-			tlsOpsCert, tlsOpsKey, _, err = CreateTLSOPSCryptoMaterial(
-				client,
+			tlsOpsCert, tlsOpsKey, _, err = pki.CreateTLSCryptoMaterialV2(
+				ctx,
 				conf,
 				&tlsParams,
 			)
@@ -1489,8 +1497,8 @@ func GetConfig(
 		signCertPem := utils.EncodeX509Certificate(signCert)
 		if signCert.NotAfter.Before(time.Now()) {
 			log.Infof("Renewing certificates using enroll")
-			signCert, signKey, signRootCert, err = CreateSignCryptoMaterial(
-				client,
+			signCert, signKey, signRootCert, err = pki.CreateSignCryptoMaterialV2(
+				ctx,
 				conf,
 				&signParams,
 			)
@@ -1501,9 +1509,9 @@ func GetConfig(
 		} else {
 			if renewCertificatesReenroll {
 				log.Infof("Renewing certificates using reenroll")
-				signCert, signKey, signRootCert, err = ReenrollSignCryptoMaterial(
+				signCert, signKey, signRootCert, err = pki.ReenrollSignCryptoMaterialV2(
+					ctx,
 					conf,
-					client,
 					&signParams,
 					string(signCertPem),
 					signKey,
@@ -1519,8 +1527,8 @@ func GetConfig(
 				if authenticationFailure {
 					log.Infof("Re enroll failed because of credentials, falling back to enroll")
 					// just enroll the user
-					signCert, signKey, signRootCert, err = CreateSignCryptoMaterial(
-						client,
+					signCert, signKey, signRootCert, err = pki.CreateSignCryptoMaterialV2(
+						ctx,
 						conf,
 						&signParams,
 					)
@@ -1531,8 +1539,8 @@ func GetConfig(
 				log.Infof("Reenrolled sign crypto material")
 			} else {
 				log.Infof("Enrolling new sign crypto material (reenroll disabled)")
-				signCert, signKey, signRootCert, err = CreateSignCryptoMaterial(
-					client,
+				signCert, signKey, signRootCert, err = pki.CreateSignCryptoMaterialV2(
+					ctx,
 					conf,
 					&signParams,
 				)
@@ -1546,8 +1554,8 @@ func GetConfig(
 	} else {
 		signCert, signKey, signRootCert, err = getExistingSignCrypto(client, chartName, namespace)
 		if err != nil {
-			signCert, signKey, signRootCert, err = CreateSignCryptoMaterial(
-				client,
+			signCert, signKey, signRootCert, err = pki.CreateSignCryptoMaterialV2(
+				ctx,
 				conf,
 				&signParams,
 			)

--- a/controllers/peer/peer_pki.go
+++ b/controllers/peer/peer_pki.go
@@ -1,0 +1,281 @@
+package peer
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+
+	hlfv1alpha1 "github.com/kfsoftware/hlf-operator/pkg/apis/hlf.kungfusoftware.es/v1alpha1"
+	"github.com/kfsoftware/hlf-operator/pkg/pki"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// pkiHelper provides PKI operations for the peer controller using the unified PKI interface
+type pkiHelper struct {
+	clientSet kubernetes.Interface
+}
+
+// newPKIHelper creates a new PKI helper
+func newPKIHelper(clientSet kubernetes.Interface) *pkiHelper {
+	return &pkiHelper{clientSet: clientSet}
+}
+
+// createProvider creates the appropriate PKI provider based on credential store configuration
+func (h *pkiHelper) createProvider(ctx context.Context, conf *hlfv1alpha1.FabricPeer, enrollment interface{}) (pki.Provider, error) {
+	switch conf.Spec.CredentialStore {
+	case hlfv1alpha1.CredentialStoreVault:
+		return h.createVaultProvider(ctx, enrollment)
+	default:
+		return h.createFabricCAProvider(ctx, enrollment)
+	}
+}
+
+// createFabricCAProvider creates a FabricCA PKI provider from enrollment config
+func (h *pkiHelper) createFabricCAProvider(ctx context.Context, enrollment interface{}) (pki.Provider, error) {
+	var caURL, caName, tlsCert, mspID string
+
+	switch e := enrollment.(type) {
+	case *hlfv1alpha1.Component:
+		cacert, err := h.getCertBytesFromCATLS(e.Catls)
+		if err != nil {
+			return nil, err
+		}
+		caURL = fmt.Sprintf("https://%s:%d", e.Cahost, e.Caport)
+		caName = e.Caname
+		tlsCert = string(cacert)
+	case *hlfv1alpha1.TLSComponent:
+		cacert, err := h.getCertBytesFromCATLS(e.Catls)
+		if err != nil {
+			return nil, err
+		}
+		caURL = fmt.Sprintf("https://%s:%d", e.Cahost, e.Caport)
+		caName = e.Caname
+		tlsCert = string(cacert)
+	default:
+		return nil, errors.New("unsupported enrollment type")
+	}
+
+	return pki.NewProvider(&pki.ProviderConfig{
+		Type:      pki.ProviderTypeFabricCA,
+		ClientSet: h.clientSet,
+		FabricCA: &pki.FabricCAConfig{
+			URL:     caURL,
+			CAName:  caName,
+			TLSCert: tlsCert,
+			MSPID:   mspID,
+		},
+	})
+}
+
+// createVaultProvider creates a Vault PKI provider from enrollment config
+func (h *pkiHelper) createVaultProvider(ctx context.Context, enrollment interface{}) (pki.Provider, error) {
+	var vaultConf *hlfv1alpha1.VaultSpecConf
+	var vaultReq *hlfv1alpha1.VaultPKICertificateRequest
+
+	switch e := enrollment.(type) {
+	case *hlfv1alpha1.Component:
+		if e.Vault == nil {
+			return nil, errors.New("vault configuration is required for vault credential store")
+		}
+		vaultConf = &e.Vault.Vault
+		vaultReq = &e.Vault.Request
+	case *hlfv1alpha1.TLSComponent:
+		if e.Vault == nil {
+			return nil, errors.New("vault configuration is required for vault credential store")
+		}
+		vaultConf = &e.Vault.Vault
+		vaultReq = &e.Vault.Request
+	default:
+		return nil, errors.New("unsupported enrollment type")
+	}
+
+	return pki.NewProvider(&pki.ProviderConfig{
+		Type:      pki.ProviderTypeVault,
+		ClientSet: h.clientSet,
+		Vault: &pki.VaultConfig{
+			URL:     vaultConf.URL,
+			PKIPath: vaultReq.PKI,
+			Role:    vaultReq.Role,
+			TTL:     vaultReq.TTL,
+			Auth: pki.VaultAuthConfig{
+				TokenSecretRef: convertSecretRef(vaultConf.TokenSecretRef),
+			},
+			TLS: pki.VaultTLSConfig{
+				CACert:             vaultConf.CACert,
+				ClientCert:         vaultConf.ClientCert,
+				ClientKeySecretRef: convertSecretRef(vaultConf.ClientKeySecretRef),
+				ServerName:         vaultConf.ServerName,
+				SkipVerify:         vaultConf.TLSSkipVerify,
+			},
+		},
+	})
+}
+
+// CreateTLSCryptoMaterialV2 creates TLS crypto material using the PKI interface
+func (h *pkiHelper) CreateTLSCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricPeer,
+	enrollment *hlfv1alpha1.TLSComponent,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+	log.Infof("Creating TLS crypto material for %s", enrollment.Enrollid)
+	log.Infof("Provider: %v", provider)
+
+	ingressHosts := conf.Spec.Hosts
+	var hosts []string
+	hosts = append(hosts, enrollment.Csr.Hosts...)
+	hosts = append(hosts, ingressHosts...)
+
+	resp, err := provider.Enroll(ctx, pki.EnrollRequest{
+		User:    enrollment.Enrollid,
+		Secret:  enrollment.Enrollsecret,
+		CN:      enrollment.Enrollid,
+		Hosts:   hosts,
+		MSPID:   conf.Spec.MspID,
+		Profile: "tls",
+	})
+	log.Infof("Response: %v", resp.Certificate)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to enroll TLS")
+	}
+
+	return resp.Certificate, resp.PrivateKey, resp.RootCertificate, nil
+}
+
+// CreateSignCryptoMaterialV2 creates sign crypto material using the PKI interface
+func (h *pkiHelper) CreateSignCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricPeer,
+	enrollment *hlfv1alpha1.Component,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+	log.Infof("Creating sign crypto material for %s", enrollment.Enrollid)
+	log.Infof("Provider: %v", provider)
+
+	resp, err := provider.Enroll(ctx, pki.EnrollRequest{
+		User:   enrollment.Enrollid,
+		Secret: enrollment.Enrollsecret,
+		CN:     conf.Name,
+		Hosts:  []string{},
+		MSPID:  conf.Spec.MspID,
+	})
+	log.Infof("Response: %v", resp.Certificate)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to enroll sign")
+	}
+
+	return resp.Certificate, resp.PrivateKey, resp.RootCertificate, nil
+}
+
+// ReenrollTLSCryptoMaterialV2 re-enrolls TLS crypto material using the PKI interface
+func (h *pkiHelper) ReenrollTLSCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricPeer,
+	enrollment *hlfv1alpha1.TLSComponent,
+	existingCert string,
+	existingKey *ecdsa.PrivateKey,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	ingressHosts := conf.Spec.Hosts
+	var hosts []string
+	hosts = append(hosts, enrollment.Csr.Hosts...)
+	hosts = append(hosts, ingressHosts...)
+
+	resp, err := provider.Reenroll(ctx, pki.ReenrollRequest{
+		EnrollID:     enrollment.Enrollid,
+		CN:           conf.Name,
+		Hosts:        hosts,
+		MSPID:        conf.Spec.MspID,
+		Profile:      "tls",
+		ExistingCert: existingCert,
+		ExistingKey:  existingKey,
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to re-enroll TLS")
+	}
+
+	return resp.Certificate, existingKey, resp.RootCertificate, nil
+}
+
+// ReenrollSignCryptoMaterialV2 re-enrolls sign crypto material using the PKI interface
+func (h *pkiHelper) ReenrollSignCryptoMaterialV2(
+	ctx context.Context,
+	conf *hlfv1alpha1.FabricPeer,
+	enrollment *hlfv1alpha1.Component,
+	existingCert string,
+	existingKey *ecdsa.PrivateKey,
+) (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, error) {
+	provider, err := h.createProvider(ctx, conf, enrollment)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create PKI provider")
+	}
+
+	resp, err := provider.Reenroll(ctx, pki.ReenrollRequest{
+		EnrollID:     enrollment.Enrollid,
+		CN:           "",
+		Hosts:        []string{},
+		MSPID:        conf.Spec.MspID,
+		Profile:      "ca",
+		ExistingCert: existingCert,
+		ExistingKey:  existingKey,
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to re-enroll sign")
+	}
+
+	return resp.Certificate, existingKey, resp.RootCertificate, nil
+}
+
+// getCertBytesFromCATLS retrieves the CA TLS certificate bytes
+func (h *pkiHelper) getCertBytesFromCATLS(caTls *hlfv1alpha1.Catls) ([]byte, error) {
+	var certBytes []byte
+	var err error
+
+	if caTls.Cacert != "" {
+		certBytes, err = base64.StdEncoding.DecodeString(caTls.Cacert)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode CA cert from base64")
+		}
+	} else if caTls.SecretRef != nil {
+		secret, err := h.clientSet.CoreV1().Secrets(caTls.SecretRef.Namespace).Get(
+			context.Background(),
+			caTls.SecretRef.Name,
+			v1.GetOptions{},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get CA cert secret")
+		}
+		certBytes = secret.Data[caTls.SecretRef.Key]
+	} else {
+		return nil, errors.New("invalid CA TLS configuration: neither cacert nor secretRef provided")
+	}
+
+	return certBytes, nil
+}
+
+// convertSecretRef converts from hlfv1alpha1.VaultSecretRef to pki.SecretRef
+func convertSecretRef(ref *hlfv1alpha1.VaultSecretRef) *pki.SecretRef {
+	if ref == nil {
+		return nil
+	}
+	return &pki.SecretRef{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+		Key:       ref.Key,
+	}
+}

--- a/pkg/pki/errors.go
+++ b/pkg/pki/errors.go
@@ -1,0 +1,10 @@
+package pki
+
+import "errors"
+
+// ErrNotSupported is returned when a PKI operation is not supported by the provider.
+// Callers should check for this sentinel to distinguish unsupported operations
+// from real failures.
+//
+//	if errors.Is(err, pki.ErrNotSupported) { ... }
+var ErrNotSupported = errors.New("operation not supported by this provider")

--- a/pkg/pki/fabricca/provider.go
+++ b/pkg/pki/fabricca/provider.go
@@ -1,0 +1,384 @@
+package fabricca
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/hyperledger/fabric/bccsp"
+	bccsputils "github.com/hyperledger/fabric/bccsp/utils"
+	"github.com/kfsoftware/hlf-operator/controllers/utils"
+	"github.com/kfsoftware/hlf-operator/internal/github.com/hyperledger/fabric-ca/api"
+	"github.com/kfsoftware/hlf-operator/internal/github.com/hyperledger/fabric-ca/lib"
+	"github.com/kfsoftware/hlf-operator/internal/github.com/hyperledger/fabric-ca/lib/client/credential"
+	fabricx509 "github.com/kfsoftware/hlf-operator/internal/github.com/hyperledger/fabric-ca/lib/client/credential/x509"
+	"github.com/kfsoftware/hlf-operator/internal/github.com/hyperledger/fabric-ca/lib/tls"
+	"github.com/kfsoftware/hlf-operator/pkg/pki"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	// Register the FabricCA provider factory
+	pki.RegisterProvider(pki.ProviderTypeFabricCA, func(config *pki.ProviderConfig) (pki.Provider, error) {
+		return NewProvider(config.FabricCA)
+	})
+}
+
+// Provider implements the pki.Provider interface for Fabric CA
+type Provider struct {
+	config *pki.FabricCAConfig
+	client *lib.Client
+}
+
+// Ensure Provider implements the pki.Provider interface
+var _ pki.Provider = (*Provider)(nil)
+var _ pki.RegistrationSupporter = (*Provider)(nil)
+var _ pki.RevocationSupporter = (*Provider)(nil)
+
+// NewProvider creates a new Fabric CA PKI provider
+func NewProvider(config *pki.FabricCAConfig) (*Provider, error) {
+	if config == nil {
+		return nil, errors.New("fabric CA config is required")
+	}
+	if config.URL == "" {
+		return nil, errors.New("fabric CA URL is required")
+	}
+
+	client, err := createClient(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Fabric CA client")
+	}
+
+	return &Provider{
+		config: config,
+		client: client,
+	}, nil
+}
+
+// Type returns the provider type
+func (p *Provider) Type() pki.ProviderType {
+	return pki.ProviderTypeFabricCA
+}
+
+// SupportsRegistration returns true as Fabric CA supports identity registration
+func (p *Provider) SupportsRegistration() bool {
+	return true
+}
+
+// SupportsRevocation returns true as Fabric CA supports certificate revocation
+func (p *Provider) SupportsRevocation() bool {
+	return true
+}
+
+// Enroll enrolls a new identity with the Fabric CA
+func (p *Provider) Enroll(ctx context.Context, req pki.EnrollRequest) (*pki.EnrollResponse, error) {
+	attrReqs := convertAttributeRequests(req.Attributes)
+
+	enrollmentRequest := &api.EnrollmentRequest{
+		Name:     req.User,
+		Secret:   req.Secret,
+		CAName:   p.config.CAName,
+		AttrReqs: attrReqs,
+		Profile:  req.Profile,
+		Label:    "",
+		Type:     "x509",
+		CSR: &api.CSRInfo{
+			Hosts: req.Hosts,
+			CN:    req.CN,
+		},
+	}
+
+	logrus.Infof("Enrolling user %s with Fabric CA", req.User)
+
+	enrollResponse, err := p.client.Enroll(enrollmentRequest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to enroll user %s", req.User)
+	}
+
+	userCrt := enrollResponse.Identity.GetECert().GetX509Cert()
+
+	info, err := p.client.GetCAInfo(&api.GetCAInfoRequest{
+		CAName: p.config.CAName,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get CA info")
+	}
+
+	rootCrt, err := utils.ParseX509Certificate(info.CAChain)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse CA chain")
+	}
+
+	userKey, err := p.readKey()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read private key")
+	}
+
+	return &pki.EnrollResponse{
+		Certificate:     userCrt,
+		PrivateKey:      userKey,
+		RootCertificate: rootCrt,
+	}, nil
+}
+
+// Reenroll re-enrolls an existing identity
+func (p *Provider) Reenroll(ctx context.Context, req pki.ReenrollRequest) (*pki.ReenrollResponse, error) {
+	if req.ExistingKey == nil {
+		return nil, errors.New("existing private key is required for re-enrollment")
+	}
+	if req.ExistingCert == "" {
+		return nil, errors.New("existing certificate is required for re-enrollment")
+	}
+
+	priv, err := bccsputils.PrivateKeyToDER(req.ExistingKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert ECDSA private key")
+	}
+
+	bccspKey, err := p.client.GetCSP().KeyImport(priv, &bccsp.ECDSAPrivateKeyImportOpts{Temporary: true})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to import private key")
+	}
+
+	signer, err := fabricx509.NewSigner(bccspKey, []byte(req.ExistingCert))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create signer")
+	}
+
+	cred := fabricx509.NewCredential("", "", p.client)
+	if err := cred.SetVal(signer); err != nil {
+		return nil, errors.Wrap(err, "failed to set credential value")
+	}
+
+	id := lib.NewIdentity(
+		p.client,
+		req.EnrollID,
+		[]credential.Credential{cred},
+	)
+
+	attrReqs := convertAttributeRequests(req.Attributes)
+
+	reenrollResponse, err := id.Reenroll(&api.ReenrollmentRequest{
+		CAName:   p.config.CAName,
+		AttrReqs: attrReqs,
+		Profile:  req.Profile,
+		Label:    "",
+		CSR: &api.CSRInfo{
+			Hosts: req.Hosts,
+			CN:    req.CN,
+			KeyRequest: &api.KeyRequest{
+				ReuseKey: true,
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to re-enroll user %s", req.EnrollID)
+	}
+
+	userCrt := reenrollResponse.Identity.GetECert().GetX509Cert()
+
+	info, err := p.client.GetCAInfo(&api.GetCAInfoRequest{
+		CAName: p.config.CAName,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get CA info")
+	}
+
+	rootCrt, err := utils.ParseX509Certificate(info.CAChain)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse CA chain")
+	}
+
+	return &pki.ReenrollResponse{
+		Certificate:     userCrt,
+		RootCertificate: rootCrt,
+	}, nil
+}
+
+// Register registers a new identity with the Fabric CA
+func (p *Provider) Register(ctx context.Context, req pki.RegisterRequest) (*pki.RegisterResponse, error) {
+	// First, enroll the registrar
+	enrollResponse, err := p.client.Enroll(&api.EnrollmentRequest{
+		Name:     req.EnrollID,
+		Secret:   req.EnrollSecret,
+		CAName:   p.config.CAName,
+		AttrReqs: []*api.AttributeRequest{},
+		Type:     req.Type,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to enroll registrar")
+	}
+
+	attrs := convertAttributes(req.Attributes)
+	maxEnrollments := req.MaxEnrollments
+	if maxEnrollments == 0 {
+		maxEnrollments = -1 // unlimited
+	}
+
+	secret, err := enrollResponse.Identity.Register(&api.RegistrationRequest{
+		Name:           req.User,
+		Type:           req.Type,
+		MaxEnrollments: maxEnrollments,
+		Affiliation:    "",
+		Attributes:     attrs,
+		CAName:         p.config.CAName,
+		Secret:         req.Secret,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to register user %s", req.User)
+	}
+
+	return &pki.RegisterResponse{
+		Secret: secret.Secret,
+	}, nil
+}
+
+// Revoke revokes a certificate
+func (p *Provider) Revoke(ctx context.Context, req pki.RevokeRequest) error {
+	// First, enroll the registrar
+	enrollResponse, err := p.client.Enroll(&api.EnrollmentRequest{
+		Name:     req.EnrollID,
+		Secret:   req.EnrollSecret,
+		CAName:   p.config.CAName,
+		AttrReqs: []*api.AttributeRequest{},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to enroll registrar for revocation")
+	}
+
+	result, err := enrollResponse.Identity.Revoke(&api.RevocationRequest{
+		Name:   req.Name,
+		Serial: req.Serial,
+		AKI:    req.AKI,
+		Reason: req.Reason,
+		GenCRL: req.GenCRL,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to revoke certificate for %s", req.Name)
+	}
+
+	logrus.Infof("Revoked certificates: %v", result.RevokedCerts)
+	return nil
+}
+
+// GetCAInfo retrieves information about the Certificate Authority
+func (p *Provider) GetCAInfo(ctx context.Context) (*pki.CAInfo, error) {
+	info, err := p.client.GetCAInfo(&api.GetCAInfoRequest{
+		CAName: p.config.CAName,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get CA info")
+	}
+
+	return &pki.CAInfo{
+		Name:    p.config.CAName,
+		CAChain: info.CAChain,
+		Version: info.Version,
+	}, nil
+}
+
+// createClient creates a Fabric CA client
+func createClient(config *pki.FabricCAConfig) (*lib.Client, error) {
+	caHomeDir, err := ioutil.TempDir("", "fabric-ca-client")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create temp directory")
+	}
+
+	client := &lib.Client{
+		HomeDir: caHomeDir,
+		Config: &lib.ClientConfig{
+			URL: config.URL,
+		},
+	}
+
+	// Configure TLS if certificate is provided
+	if config.TLSCert != "" {
+		caCertFile, err := ioutil.TempFile("", "ca-cert")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create temp file for CA cert")
+		}
+
+		if _, err = caCertFile.Write([]byte(config.TLSCert)); err != nil {
+			return nil, errors.Wrap(err, "failed to write CA cert")
+		}
+
+		client.Config.TLS = tls.ClientTLSConfig{
+			Enabled:   true,
+			CertFiles: []string{caCertFile.Name()},
+		}
+	} else {
+		client.Config.TLS = tls.ClientTLSConfig{
+			Enabled: false,
+		}
+	}
+
+	if err := client.Init(); err != nil {
+		return nil, errors.Wrap(err, "failed to initialize Fabric CA client")
+	}
+
+	return client, nil
+}
+
+// readKey reads the private key from the client's keystore
+func (p *Provider) readKey() (*ecdsa.PrivateKey, error) {
+	keystoreDir := filepath.Join(p.client.HomeDir, "msp", "keystore")
+	files, err := ioutil.ReadDir(keystoreDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read keystore directory")
+	}
+
+	if len(files) == 0 {
+		return nil, errors.New("no key found in keystore")
+	}
+	if len(files) > 1 {
+		return nil, errors.New("multiple keys found in keystore")
+	}
+
+	keyPath := filepath.Join(keystoreDir, files[0].Name())
+	keyBytes, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read key file %s", keyPath)
+	}
+
+	ecdsaKey, err := utils.ParseECDSAPrivateKey(keyBytes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse key file %s", keyPath)
+	}
+
+	return ecdsaKey, nil
+}
+
+// convertAttributeRequests converts pki.AttributeRequest to api.AttributeRequest
+func convertAttributeRequests(attrs []pki.AttributeRequest) []*api.AttributeRequest {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	result := make([]*api.AttributeRequest, len(attrs))
+	for i, attr := range attrs {
+		result[i] = &api.AttributeRequest{
+			Name:     attr.Name,
+			Optional: attr.Optional,
+		}
+	}
+	return result
+}
+
+// convertAttributes converts pki.Attribute to api.Attribute
+func convertAttributes(attrs []pki.Attribute) []api.Attribute {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	result := make([]api.Attribute, len(attrs))
+	for i, attr := range attrs {
+		result[i] = api.Attribute{
+			Name:  attr.Name,
+			Value: attr.Value,
+			ECert: attr.ECert,
+		}
+	}
+	return result
+}

--- a/pkg/pki/fabricca/provider.go
+++ b/pkg/pki/fabricca/provider.go
@@ -3,7 +3,7 @@ package fabricca
 import (
 	"context"
 	"crypto/ecdsa"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/hyperledger/fabric/bccsp"
@@ -281,7 +281,7 @@ func (p *Provider) GetCAInfo(ctx context.Context) (*pki.CAInfo, error) {
 
 // createClient creates a Fabric CA client
 func createClient(config *pki.FabricCAConfig) (*lib.Client, error) {
-	caHomeDir, err := ioutil.TempDir("", "fabric-ca-client")
+	caHomeDir, err := os.MkdirTemp("", "fabric-ca-client")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temp directory")
 	}
@@ -295,7 +295,7 @@ func createClient(config *pki.FabricCAConfig) (*lib.Client, error) {
 
 	// Configure TLS if certificate is provided
 	if config.TLSCert != "" {
-		caCertFile, err := ioutil.TempFile("", "ca-cert")
+		caCertFile, err := os.CreateTemp("", "ca-cert")
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create temp file for CA cert")
 		}
@@ -324,7 +324,7 @@ func createClient(config *pki.FabricCAConfig) (*lib.Client, error) {
 // readKey reads the private key from the client's keystore
 func (p *Provider) readKey() (*ecdsa.PrivateKey, error) {
 	keystoreDir := filepath.Join(p.client.HomeDir, "msp", "keystore")
-	files, err := ioutil.ReadDir(keystoreDir)
+	files, err := os.ReadDir(keystoreDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read keystore directory")
 	}
@@ -337,7 +337,7 @@ func (p *Provider) readKey() (*ecdsa.PrivateKey, error) {
 	}
 
 	keyPath := filepath.Join(keystoreDir, files[0].Name())
-	keyBytes, err := ioutil.ReadFile(keyPath)
+	keyBytes, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read key file %s", keyPath)
 	}

--- a/pkg/pki/factory.go
+++ b/pkg/pki/factory.go
@@ -1,0 +1,82 @@
+package pki
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ProviderFactory is a function that creates a Provider from a ProviderConfig
+type ProviderFactory func(config *ProviderConfig) (Provider, error)
+
+var (
+	providerFactories = make(map[ProviderType]ProviderFactory)
+	factoryMutex      sync.RWMutex
+)
+
+// RegisterProvider registers a provider factory for a given provider type.
+// This should be called in the init() function of each provider package.
+func RegisterProvider(providerType ProviderType, factory ProviderFactory) {
+	factoryMutex.Lock()
+	defer factoryMutex.Unlock()
+	providerFactories[providerType] = factory
+}
+
+// NewProvider creates a PKI provider based on the given configuration.
+// This is the main entry point for creating PKI providers.
+func NewProvider(config *ProviderConfig) (Provider, error) {
+	if config == nil {
+		return nil, errors.New("provider config is required")
+	}
+
+	factoryMutex.RLock()
+	factory, ok := providerFactories[config.Type]
+	factoryMutex.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("no provider registered for type: %s", config.Type)
+	}
+
+	return factory(config)
+}
+
+// NewProviderFromCredentialStore creates a PKI provider based on the credential store type.
+// This is a convenience function that maps credential store types to provider types.
+func NewProviderFromCredentialStore(
+	credentialStore string,
+	clientSet kubernetes.Interface,
+	fabricCAConfig *FabricCAConfig,
+	vaultConfig *VaultConfig,
+) (Provider, error) {
+	var providerType ProviderType
+
+	switch credentialStore {
+	case "vault":
+		providerType = ProviderTypeVault
+	case "kubernetes", "":
+		providerType = ProviderTypeFabricCA
+	default:
+		return nil, fmt.Errorf("unsupported credential store: %s", credentialStore)
+	}
+
+	return NewProvider(&ProviderConfig{
+		Type:      providerType,
+		ClientSet: clientSet,
+		FabricCA:  fabricCAConfig,
+		Vault:     vaultConfig,
+	})
+}
+
+// GetRegisteredProviders returns a list of registered provider types
+func GetRegisteredProviders() []ProviderType {
+	factoryMutex.RLock()
+	defer factoryMutex.RUnlock()
+
+	types := make([]ProviderType, 0, len(providerFactories))
+	for t := range providerFactories {
+		types = append(types, t)
+	}
+	return types
+}

--- a/pkg/pki/helpers.go
+++ b/pkg/pki/helpers.go
@@ -1,0 +1,204 @@
+package pki
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CryptoMaterial holds the certificate and key material
+type CryptoMaterial struct {
+	Certificate     *x509.Certificate
+	PrivateKey      *ecdsa.PrivateKey
+	RootCertificate *x509.Certificate
+}
+
+// EnrollmentHelper provides a simplified API for enrollment operations.
+// It handles the complexity of choosing the right provider based on configuration.
+type EnrollmentHelper struct {
+	clientSet kubernetes.Interface
+}
+
+// NewEnrollmentHelper creates a new EnrollmentHelper
+func NewEnrollmentHelper(clientSet kubernetes.Interface) *EnrollmentHelper {
+	return &EnrollmentHelper{
+		clientSet: clientSet,
+	}
+}
+
+// EnrollWithFabricCA enrolls a user using Fabric CA
+func (h *EnrollmentHelper) EnrollWithFabricCA(
+	ctx context.Context,
+	caURL string,
+	caName string,
+	tlsCert string,
+	mspID string,
+	user string,
+	secret string,
+	hosts []string,
+	cn string,
+	profile string,
+) (*CryptoMaterial, error) {
+	provider, err := NewProvider(&ProviderConfig{
+		Type:      ProviderTypeFabricCA,
+		ClientSet: h.clientSet,
+		FabricCA: &FabricCAConfig{
+			URL:     caURL,
+			CAName:  caName,
+			TLSCert: tlsCert,
+			MSPID:   mspID,
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create FabricCA provider")
+	}
+
+	resp, err := provider.Enroll(ctx, EnrollRequest{
+		User:    user,
+		Secret:  secret,
+		Hosts:   hosts,
+		CN:      cn,
+		MSPID:   mspID,
+		Profile: profile,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to enroll user")
+	}
+
+	return &CryptoMaterial{
+		Certificate:     resp.Certificate,
+		PrivateKey:      resp.PrivateKey,
+		RootCertificate: resp.RootCertificate,
+	}, nil
+}
+
+// EnrollWithVault enrolls a user using Vault PKI
+func (h *EnrollmentHelper) EnrollWithVault(
+	ctx context.Context,
+	vaultURL string,
+	pkiPath string,
+	role string,
+	ttl string,
+	tokenSecretRef *SecretRef,
+	mspID string,
+	user string,
+	hosts []string,
+	cn string,
+) (*CryptoMaterial, error) {
+	provider, err := NewProvider(&ProviderConfig{
+		Type:      ProviderTypeVault,
+		ClientSet: h.clientSet,
+		Vault: &VaultConfig{
+			URL:     vaultURL,
+			PKIPath: pkiPath,
+			Role:    role,
+			TTL:     ttl,
+			Auth: VaultAuthConfig{
+				TokenSecretRef: tokenSecretRef,
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Vault provider")
+	}
+
+	resp, err := provider.Enroll(ctx, EnrollRequest{
+		User:  user,
+		Hosts: hosts,
+		CN:    cn,
+		MSPID: mspID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to enroll user")
+	}
+
+	return &CryptoMaterial{
+		Certificate:     resp.Certificate,
+		PrivateKey:      resp.PrivateKey,
+		RootCertificate: resp.RootCertificate,
+	}, nil
+}
+
+// Reenroll re-enrolls an existing identity
+func (h *EnrollmentHelper) Reenroll(
+	ctx context.Context,
+	provider Provider,
+	enrollID string,
+	existingCert string,
+	existingKey *ecdsa.PrivateKey,
+	hosts []string,
+	cn string,
+	mspID string,
+	profile string,
+) (*CryptoMaterial, error) {
+	resp, err := provider.Reenroll(ctx, ReenrollRequest{
+		EnrollID:     enrollID,
+		ExistingCert: existingCert,
+		ExistingKey:  existingKey,
+		Hosts:        hosts,
+		CN:           cn,
+		MSPID:        mspID,
+		Profile:      profile,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to re-enroll user")
+	}
+
+	return &CryptoMaterial{
+		Certificate:     resp.Certificate,
+		PrivateKey:      existingKey, // Key is reused
+		RootCertificate: resp.RootCertificate,
+	}, nil
+}
+
+// CreateProviderFromConfig is a helper function to create a provider from
+// generic configuration parameters. This is useful when you have the
+// configuration split across different sources.
+func CreateProviderFromConfig(
+	credentialStore string,
+	clientSet kubernetes.Interface,
+	// FabricCA config
+	caURL string,
+	caName string,
+	tlsCert string,
+	mspID string,
+	// Vault config
+	vaultURL string,
+	pkiPath string,
+	role string,
+	ttl string,
+	tokenSecretRef *SecretRef,
+) (Provider, error) {
+	switch credentialStore {
+	case "vault":
+		return NewProvider(&ProviderConfig{
+			Type:      ProviderTypeVault,
+			ClientSet: clientSet,
+			Vault: &VaultConfig{
+				URL:     vaultURL,
+				PKIPath: pkiPath,
+				Role:    role,
+				TTL:     ttl,
+				Auth: VaultAuthConfig{
+					TokenSecretRef: tokenSecretRef,
+				},
+			},
+		})
+	case "kubernetes", "":
+		return NewProvider(&ProviderConfig{
+			Type:      ProviderTypeFabricCA,
+			ClientSet: clientSet,
+			FabricCA: &FabricCAConfig{
+				URL:     caURL,
+				CAName:  caName,
+				TLSCert: tlsCert,
+				MSPID:   mspID,
+			},
+		})
+	default:
+		return nil, errors.Errorf("unsupported credential store: %s", credentialStore)
+	}
+}

--- a/pkg/pki/interface.go
+++ b/pkg/pki/interface.go
@@ -1,0 +1,44 @@
+package pki
+
+import (
+	"context"
+)
+
+// Provider defines the interface for PKI operations.
+// Both Fabric CA and HashiCorp Vault implement this interface.
+type Provider interface {
+	// Enroll enrolls a new identity and returns the certificate and private key
+	Enroll(ctx context.Context, req EnrollRequest) (*EnrollResponse, error)
+
+	// Reenroll re-enrolls an existing identity using the existing key
+	Reenroll(ctx context.Context, req ReenrollRequest) (*ReenrollResponse, error)
+
+	// Register registers a new identity with the CA (returns enrollment secret)
+	// Note: This may not be supported by all providers (e.g., Vault PKI)
+	Register(ctx context.Context, req RegisterRequest) (*RegisterResponse, error)
+
+	// Revoke revokes a certificate
+	// Note: This may not be supported by all providers
+	Revoke(ctx context.Context, req RevokeRequest) error
+
+	// GetCAInfo retrieves information about the Certificate Authority
+	GetCAInfo(ctx context.Context) (*CAInfo, error)
+
+	// Type returns the provider type
+	Type() ProviderType
+}
+
+// RegistrationSupporter is an optional interface for providers that support
+// identity registration. Fabric CA supports this, but Vault PKI does not
+// have native identity registration.
+type RegistrationSupporter interface {
+	// SupportsRegistration returns true if the provider supports identity registration
+	SupportsRegistration() bool
+}
+
+// RevocationSupporter is an optional interface for providers that support
+// certificate revocation.
+type RevocationSupporter interface {
+	// SupportsRevocation returns true if the provider supports certificate revocation
+	SupportsRevocation() bool
+}

--- a/pkg/pki/types.go
+++ b/pkg/pki/types.go
@@ -1,0 +1,231 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// EnrollRequest contains the parameters needed for enrolling a new identity
+type EnrollRequest struct {
+	// User is the enrollment ID
+	User string
+	// Secret is the enrollment secret (used by Fabric CA, ignored by Vault)
+	Secret string
+	// CommonName for the certificate
+	CN string
+	// Hosts are the DNS/IP SANs to include in the certificate
+	Hosts []string
+	// MSPID is the Membership Service Provider ID
+	MSPID string
+	// Profile is the enrollment profile (e.g., "tls", "ca")
+	Profile string
+	// Attributes to include in the certificate
+	Attributes []AttributeRequest
+}
+
+// ReenrollRequest contains parameters for re-enrolling an existing identity
+type ReenrollRequest struct {
+	// EnrollID is the identity's enrollment ID
+	EnrollID string
+	// CommonName for the certificate
+	CN string
+	// Hosts are the DNS/IP SANs to include in the certificate
+	Hosts []string
+	// MSPID is the Membership Service Provider ID
+	MSPID string
+	// Profile is the enrollment profile
+	Profile string
+	// Attributes to include in the certificate
+	Attributes []AttributeRequest
+	// ExistingCert is the current certificate PEM
+	ExistingCert string
+	// ExistingKey is the existing private key to reuse
+	ExistingKey *ecdsa.PrivateKey
+}
+
+// RegisterRequest contains parameters for registering a new identity
+type RegisterRequest struct {
+	// EnrollID is the registrar's enrollment ID
+	EnrollID string
+	// EnrollSecret is the registrar's enrollment secret
+	EnrollSecret string
+	// User is the new user's enrollment ID
+	User string
+	// Secret is the new user's enrollment secret
+	Secret string
+	// Type is the identity type (e.g., "client", "peer", "orderer")
+	Type string
+	// MSPID is the Membership Service Provider ID
+	MSPID string
+	// Attributes to assign to the identity
+	Attributes []Attribute
+	// MaxEnrollments is the maximum number of times the identity can enroll (-1 for unlimited)
+	MaxEnrollments int
+}
+
+// RevokeRequest contains parameters for revoking a certificate
+type RevokeRequest struct {
+	// EnrollID is the registrar's enrollment ID
+	EnrollID string
+	// EnrollSecret is the registrar's enrollment secret
+	EnrollSecret string
+	// Name is the identity name to revoke
+	Name string
+	// Serial is the certificate serial number (optional)
+	Serial string
+	// AKI is the Authority Key Identifier (optional)
+	AKI string
+	// Reason is the revocation reason
+	Reason string
+	// GenCRL indicates whether to generate a new CRL
+	GenCRL bool
+}
+
+// EnrollResponse contains the results of an enrollment operation
+type EnrollResponse struct {
+	// Certificate is the enrolled certificate
+	Certificate *x509.Certificate
+	// PrivateKey is the private key for the certificate
+	PrivateKey *ecdsa.PrivateKey
+	// RootCertificate is the CA's root certificate
+	RootCertificate *x509.Certificate
+}
+
+// ReenrollResponse contains the results of a re-enrollment operation
+type ReenrollResponse struct {
+	// Certificate is the renewed certificate
+	Certificate *x509.Certificate
+	// RootCertificate is the CA's root certificate
+	RootCertificate *x509.Certificate
+}
+
+// RegisterResponse contains the results of a registration operation
+type RegisterResponse struct {
+	// Secret is the enrollment secret for the registered identity
+	Secret string
+}
+
+// CAInfo contains information about a Certificate Authority
+type CAInfo struct {
+	// Name is the CA name
+	Name string
+	// CAChain is the certificate chain in PEM format
+	CAChain []byte
+	// Version is the CA version
+	Version string
+}
+
+// AttributeRequest specifies an attribute to request during enrollment
+type AttributeRequest struct {
+	// Name is the attribute name
+	Name string
+	// Optional indicates if the attribute is optional
+	Optional bool
+}
+
+// Attribute represents an attribute to assign during registration
+type Attribute struct {
+	// Name is the attribute name
+	Name string
+	// Value is the attribute value
+	Value string
+	// ECert indicates if the attribute should be included in the enrollment certificate
+	ECert bool
+}
+
+// ProviderConfig holds the configuration needed to create a PKI provider
+type ProviderConfig struct {
+	// Type specifies the provider type ("fabricca" or "vault")
+	Type ProviderType
+
+	// Kubernetes clientset for accessing secrets
+	ClientSet kubernetes.Interface
+
+	// FabricCA-specific configuration
+	FabricCA *FabricCAConfig
+
+	// Vault-specific configuration
+	Vault *VaultConfig
+}
+
+// ProviderType represents the type of PKI provider
+type ProviderType string
+
+const (
+	// ProviderTypeFabricCA indicates a Fabric CA provider
+	ProviderTypeFabricCA ProviderType = "fabricca"
+	// ProviderTypeVault indicates a HashiCorp Vault provider
+	ProviderTypeVault ProviderType = "vault"
+)
+
+// FabricCAConfig contains configuration for connecting to a Fabric CA
+type FabricCAConfig struct {
+	// URL is the CA server URL
+	URL string
+	// CAName is the name of the CA
+	CAName string
+	// TLSCert is the TLS certificate for connecting to the CA (PEM format)
+	TLSCert string
+	// MSPID is the MSP identifier
+	MSPID string
+}
+
+// VaultConfig contains configuration for connecting to HashiCorp Vault
+type VaultConfig struct {
+	// URL is the Vault server URL
+	URL string
+	// PKIPath is the path to the PKI secrets engine
+	PKIPath string
+	// Role is the PKI role to use for issuing certificates
+	Role string
+	// TTL is the requested certificate TTL
+	TTL string
+	// Auth contains authentication configuration
+	Auth VaultAuthConfig
+	// TLS contains TLS configuration
+	TLS VaultTLSConfig
+}
+
+// VaultAuthConfig contains Vault authentication configuration
+type VaultAuthConfig struct {
+	// TokenSecretRef references a Kubernetes secret containing the Vault token
+	TokenSecretRef *SecretRef
+	// KubernetesAuth contains Kubernetes auth method configuration
+	KubernetesAuth *VaultKubernetesAuth
+}
+
+// VaultKubernetesAuth contains Vault Kubernetes auth configuration
+type VaultKubernetesAuth struct {
+	// Role is the Vault role for Kubernetes auth
+	Role string
+	// MountPath is the auth method mount path
+	MountPath string
+	// ServiceAccountTokenPath is the path to the service account token
+	ServiceAccountTokenPath string
+}
+
+// VaultTLSConfig contains Vault TLS configuration
+type VaultTLSConfig struct {
+	// CACert is the CA certificate for verifying the Vault server
+	CACert string
+	// ClientCert is the client certificate for mTLS
+	ClientCert string
+	// ClientKeySecretRef references a Kubernetes secret containing the client key
+	ClientKeySecretRef *SecretRef
+	// ServerName is the expected server name for TLS verification
+	ServerName string
+	// SkipVerify disables TLS verification
+	SkipVerify bool
+}
+
+// SecretRef references a key in a Kubernetes secret
+type SecretRef struct {
+	// Namespace is the secret namespace
+	Namespace string
+	// Name is the secret name
+	Name string
+	// Key is the key within the secret
+	Key string
+}

--- a/pkg/pki/vault/provider.go
+++ b/pkg/pki/vault/provider.go
@@ -1,0 +1,431 @@
+package vault
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault-client-go"
+	"github.com/kfsoftware/hlf-operator/pkg/pki"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	// Register the Vault provider factory
+	pki.RegisterProvider(pki.ProviderTypeVault, func(config *pki.ProviderConfig) (pki.Provider, error) {
+		return NewProvider(config.Vault, config.ClientSet)
+	})
+}
+
+// Provider implements the pki.Provider interface for HashiCorp Vault
+type Provider struct {
+	config    *pki.VaultConfig
+	client    *vault.Client
+	clientSet kubernetes.Interface
+}
+
+// Ensure Provider implements the pki.Provider interface
+var _ pki.Provider = (*Provider)(nil)
+var _ pki.RegistrationSupporter = (*Provider)(nil)
+var _ pki.RevocationSupporter = (*Provider)(nil)
+
+// NewProvider creates a new Vault PKI provider
+func NewProvider(config *pki.VaultConfig, clientSet kubernetes.Interface) (*Provider, error) {
+	if config == nil {
+		return nil, errors.New("vault config is required")
+	}
+	if config.URL == "" {
+		return nil, errors.New("vault URL is required")
+	}
+	if config.PKIPath == "" {
+		return nil, errors.New("vault PKI path is required")
+	}
+	if config.Role == "" {
+		return nil, errors.New("vault PKI role is required")
+	}
+	if clientSet == nil {
+		return nil, errors.New("kubernetes clientset is required")
+	}
+
+	client, err := createVaultClient(config, clientSet)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Vault client")
+	}
+
+	return &Provider{
+		config:    config,
+		client:    client,
+		clientSet: clientSet,
+	}, nil
+}
+
+// Type returns the provider type
+func (p *Provider) Type() pki.ProviderType {
+	return pki.ProviderTypeVault
+}
+
+// SupportsRegistration returns false as Vault PKI doesn't have native identity registration
+func (p *Provider) SupportsRegistration() bool {
+	return false
+}
+
+// SupportsRevocation returns true as Vault PKI supports certificate revocation
+func (p *Provider) SupportsRevocation() bool {
+	return true
+}
+
+// Enroll enrolls a new identity using Vault PKI
+func (p *Provider) Enroll(ctx context.Context, req pki.EnrollRequest) (*pki.EnrollResponse, error) {
+	// Generate a new private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate private key")
+	}
+
+	// Create CSR
+	commonName := req.User
+	if req.CN != "" {
+		commonName = req.CN
+	}
+
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+	}
+
+	if len(req.Hosts) > 0 {
+		template.DNSNames = req.Hosts
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create CSR")
+	}
+
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrDER,
+	})
+
+	// Prepare request data for Vault
+	csrData := map[string]interface{}{
+		"csr":                 string(csrPEM),
+		"common_name":         commonName,
+		"use_csr_common_name": true,
+		"use_csr_sans":        true,
+	}
+
+	if p.config.TTL != "" {
+		csrData["ttl"] = p.config.TTL
+	}
+
+	logrus.Infof("Enrolling user %s with Vault PKI", req.User)
+
+	// Request certificate from Vault PKI
+	secret, err := p.client.Write(
+		ctx,
+		fmt.Sprintf("%s/sign/%s", p.config.PKIPath, p.config.Role),
+		csrData,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign CSR with Vault PKI")
+	}
+
+	// Parse the signed certificate
+	certPEM, ok := secret.Data["certificate"].(string)
+	if !ok {
+		return nil, errors.New("failed to get certificate from Vault response")
+	}
+
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return nil, errors.New("failed to decode certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse certificate")
+	}
+
+	// Parse the CA certificate
+	caPEM, ok := secret.Data["issuing_ca"].(string)
+	if !ok {
+		return nil, errors.New("failed to get issuing CA from Vault response")
+	}
+
+	caBlock, _ := pem.Decode([]byte(caPEM))
+	if caBlock == nil {
+		return nil, errors.New("failed to decode CA certificate PEM")
+	}
+
+	caCert, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse CA certificate")
+	}
+
+	return &pki.EnrollResponse{
+		Certificate:     cert,
+		PrivateKey:      privateKey,
+		RootCertificate: caCert,
+	}, nil
+}
+
+// Reenroll re-enrolls an existing identity using the existing key
+func (p *Provider) Reenroll(ctx context.Context, req pki.ReenrollRequest) (*pki.ReenrollResponse, error) {
+	if req.ExistingKey == nil {
+		return nil, errors.New("existing private key is required for re-enrollment")
+	}
+
+	commonName := req.EnrollID
+	if req.CN != "" {
+		commonName = req.CN
+	}
+
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, template, req.ExistingKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create CSR")
+	}
+
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrDER,
+	})
+
+	csrData := map[string]interface{}{
+		"csr":                 string(csrPEM),
+		"common_name":         commonName,
+		"use_csr_common_name": true,
+		"use_csr_sans":        true,
+		"key_type":            "ec",
+	}
+
+	if len(req.Hosts) > 0 {
+		csrData["alt_names"] = strings.Join(req.Hosts, ",")
+	}
+
+	if p.config.TTL != "" {
+		csrData["ttl"] = p.config.TTL
+	}
+
+	logrus.Infof("Re-enrolling user %s with Vault PKI", req.EnrollID)
+
+	secret, err := p.client.Write(
+		ctx,
+		fmt.Sprintf("%s/sign/%s", p.config.PKIPath, p.config.Role),
+		csrData,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign CSR with Vault PKI")
+	}
+
+	// Parse the signed certificate
+	certPEM, ok := secret.Data["certificate"].(string)
+	if !ok {
+		return nil, errors.New("failed to get certificate from Vault response")
+	}
+
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return nil, errors.New("failed to decode certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse certificate")
+	}
+
+	// Parse the CA certificate
+	caPEM, ok := secret.Data["issuing_ca"].(string)
+	if !ok {
+		return nil, errors.New("failed to get issuing CA from Vault response")
+	}
+
+	caBlock, _ := pem.Decode([]byte(caPEM))
+	if caBlock == nil {
+		return nil, errors.New("failed to decode CA certificate PEM")
+	}
+
+	caCert, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse CA certificate")
+	}
+
+	return &pki.ReenrollResponse{
+		Certificate:     cert,
+		RootCertificate: caCert,
+	}, nil
+}
+
+// Register is not supported by Vault PKI
+func (p *Provider) Register(ctx context.Context, req pki.RegisterRequest) (*pki.RegisterResponse, error) {
+	return nil, errors.New("identity registration is not supported by Vault PKI provider")
+}
+
+// Revoke revokes a certificate using Vault PKI
+func (p *Provider) Revoke(ctx context.Context, req pki.RevokeRequest) error {
+	// Vault PKI revocation requires the certificate serial number
+	if req.Serial == "" {
+		return errors.New("certificate serial number is required for Vault revocation")
+	}
+
+	revokeData := map[string]interface{}{
+		"serial_number": req.Serial,
+	}
+
+	_, err := p.client.Write(
+		ctx,
+		fmt.Sprintf("%s/revoke", p.config.PKIPath),
+		revokeData,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to revoke certificate")
+	}
+
+	logrus.Infof("Revoked certificate with serial %s", req.Serial)
+	return nil
+}
+
+// GetCAInfo retrieves information about the Vault PKI CA
+func (p *Provider) GetCAInfo(ctx context.Context) (*pki.CAInfo, error) {
+	// Read the CA certificate from Vault
+	secret, err := p.client.Read(
+		ctx,
+		fmt.Sprintf("%s/cert/ca", p.config.PKIPath),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read CA certificate from Vault")
+	}
+
+	caCert, ok := secret.Data["certificate"].(string)
+	if !ok {
+		return nil, errors.New("failed to get CA certificate from Vault response")
+	}
+
+	return &pki.CAInfo{
+		Name:    p.config.PKIPath,
+		CAChain: []byte(caCert),
+	}, nil
+}
+
+// createVaultClient creates and configures a Vault client
+func createVaultClient(config *pki.VaultConfig, clientSet kubernetes.Interface) (*vault.Client, error) {
+	vaultConfig := vault.DefaultConfiguration()
+	vaultConfig.Address = config.URL
+
+	var tlsConf vault.TLSConfiguration
+
+	// Configure TLS
+	if config.TLS.ClientCert != "" && config.TLS.ClientKeySecretRef != nil {
+		// Get the client key from the referenced secret
+		secretNamespace := config.TLS.ClientKeySecretRef.Namespace
+		if secretNamespace == "" {
+			secretNamespace = "default"
+		}
+
+		secret, err := clientSet.CoreV1().Secrets(secretNamespace).Get(
+			context.Background(),
+			config.TLS.ClientKeySecretRef.Name,
+			v1.GetOptions{},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get client key secret")
+		}
+
+		clientKey := secret.Data[config.TLS.ClientKeySecretRef.Key]
+		if clientKey == nil {
+			return nil, fmt.Errorf("key %s not found in the secret", config.TLS.ClientKeySecretRef.Key)
+		}
+
+		tlsConf = vault.TLSConfiguration{
+			ServerName: config.TLS.ServerName,
+			ClientCertificate: vault.ClientCertificateEntry{
+				FromBytes: []byte(config.TLS.ClientCert),
+			},
+			ClientCertificateKey: vault.ClientCertificateKeyEntry{
+				FromBytes: clientKey,
+			},
+			InsecureSkipVerify: config.TLS.SkipVerify,
+		}
+
+		if config.TLS.CACert != "" {
+			tlsConf.ServerCertificate = vault.ServerCertificateEntry{
+				FromBytes: []byte(config.TLS.CACert),
+			}
+		}
+	} else if config.TLS.SkipVerify {
+		tlsConf = vault.TLSConfiguration{
+			InsecureSkipVerify: true,
+		}
+	} else if config.TLS.CACert != "" {
+		tlsConf = vault.TLSConfiguration{
+			ServerCertificate: vault.ServerCertificateEntry{
+				FromBytes: []byte(config.TLS.CACert),
+			},
+			InsecureSkipVerify: config.TLS.SkipVerify,
+		}
+	}
+
+	// Set timeout
+	vaultConfig.RequestTimeout = 30 * time.Second
+
+	vaultClientOpts := []vault.ClientOption{
+		vault.WithAddress(vaultConfig.Address),
+		vault.WithHTTPClient(vaultConfig.HTTPClient),
+		vault.WithRetryConfiguration(vaultConfig.RetryConfiguration),
+		vault.WithRequestTimeout(vaultConfig.RequestTimeout),
+		vault.WithTLS(tlsConf),
+	}
+
+	client, err := vault.New(vaultClientOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Vault client")
+	}
+
+	// Handle authentication
+	if config.Auth.TokenSecretRef != nil && config.Auth.TokenSecretRef.Name != "" {
+		secretNamespace := config.Auth.TokenSecretRef.Namespace
+		if secretNamespace == "" {
+			secretNamespace = "default"
+		}
+
+		secret, err := clientSet.CoreV1().Secrets(secretNamespace).Get(
+			context.Background(),
+			config.Auth.TokenSecretRef.Name,
+			v1.GetOptions{},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get token secret")
+		}
+
+		tokenBytes := secret.Data[config.Auth.TokenSecretRef.Key]
+		if tokenBytes == nil {
+			return nil, fmt.Errorf("key %s not found in token secret", config.Auth.TokenSecretRef.Key)
+		}
+
+		client.SetToken(string(tokenBytes))
+	} else if config.Auth.KubernetesAuth != nil {
+		// TODO: Implement Kubernetes auth method
+		return nil, errors.New("Kubernetes auth method not yet implemented")
+	} else {
+		return nil, errors.New("no authentication method provided for Vault")
+	}
+
+	return client, nil
+}

--- a/pkg/pki/vault/provider.go
+++ b/pkg/pki/vault/provider.go
@@ -275,7 +275,7 @@ func (p *Provider) Reenroll(ctx context.Context, req pki.ReenrollRequest) (*pki.
 
 // Register is not supported by Vault PKI
 func (p *Provider) Register(ctx context.Context, req pki.RegisterRequest) (*pki.RegisterResponse, error) {
-	return nil, errors.New("identity registration is not supported by Vault PKI provider")
+	return nil, pki.ErrNotSupported
 }
 
 // Revoke revokes a certificate using Vault PKI
@@ -419,7 +419,9 @@ func createVaultClient(config *pki.VaultConfig, clientSet kubernetes.Interface) 
 			return nil, fmt.Errorf("key %s not found in token secret", config.Auth.TokenSecretRef.Key)
 		}
 
-		client.SetToken(string(tokenBytes))
+		if err := client.SetToken(string(tokenBytes)); err != nil {
+			return nil, errors.Wrap(err, "failed to set Vault token")
+		}
 	} else if config.Auth.KubernetesAuth != nil {
 		// TODO: Implement Kubernetes auth method
 		return nil, errors.New("Kubernetes auth method not yet implemented")


### PR DESCRIPTION
- Added a new `pki` package to provide a unified interface for PKI operations.
- Deprecated the existing `certs` and `certs_vault` packages, with migration guides included.
- Implemented `pkiHelper` for managing PKI operations in the identity, orderer node, and peer controllers.
- Updated controllers to utilize the new PKI interface for certificate enrollment and renewal processes.
- Added provider registration for both Fabric CA and Vault in the new PKI architecture.

<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/hyperledger-bevel/bevel-operator-fabric/issues/293

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
