### PR TITLE
fix(security): add gosec annotations and tighten file permissions

### DIFF
--- a/controllers/ca/ca_controller.go
+++ b/controllers/ca/ca_controller.go
@@ -1022,7 +1022,7 @@ func GetCAState(clientSet *kubernetes.Clientset, ca *hlfv1alpha1.FabricCA, relea
 		if ca.Spec.Replicas != nil {
 			replicas = *ca.Spec.Replicas
 		}
-		if dep.Status.ReadyReplicas == int32(replicas) {
+		if dep.Status.ReadyReplicas == int32(replicas) { //nolint:gosec // replica count fits int32
 			r.Status = hlfv1alpha1.RunningStatus
 		} else {
 			r.Status = hlfv1alpha1.PendingStatus

--- a/controllers/chaincode/deploy/chaincode_deploy_controller.go
+++ b/controllers/chaincode/deploy/chaincode_deploy_controller.go
@@ -429,7 +429,7 @@ func (r *FabricChaincodeDeployReconciler) Reconcile(ctx context.Context, req ctr
 				TCPSocket: &corev1.TCPSocketAction{
 					Port: intstr.IntOrString{
 						Type:   intstr.Int,
-						IntVal: int32(chaincodePort),
+						IntVal: int32(chaincodePort), //nolint:gosec // port number fits int32
 					},
 				},
 			},
@@ -445,7 +445,7 @@ func (r *FabricChaincodeDeployReconciler) Reconcile(ctx context.Context, req ctr
 				TCPSocket: &corev1.TCPSocketAction{
 					Port: intstr.IntOrString{
 						Type:   intstr.Int,
-						IntVal: int32(chaincodePort),
+						IntVal: int32(chaincodePort), //nolint:gosec // port number fits int32
 					},
 				},
 			},
@@ -495,7 +495,7 @@ func (r *FabricChaincodeDeployReconciler) Reconcile(ctx context.Context, req ctr
 			Annotations: fabricChaincode.Spec.Annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: func(i int32) *int32 { return &i }(int32(replicas)),
+			Replicas: func(i int32) *int32 { return &i }(int32(replicas)), //nolint:gosec // replica count fits int32
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/controllers/mainchannel/mainchannel_controller.go
+++ b/controllers/mainchannel/mainchannel_controller.go
@@ -1406,9 +1406,9 @@ func (r *FabricMainChannelReconciler) mapToConfigTX(channel *hlfv1alpha1.FabricM
 				ordConfigtx.BatchTimeout = batchTimeout
 			}
 			if channel.Spec.ChannelConfig.Orderer.BatchSize != nil {
-				ordConfigtx.BatchSize.MaxMessageCount = uint32(channel.Spec.ChannelConfig.Orderer.BatchSize.MaxMessageCount)
-				ordConfigtx.BatchSize.AbsoluteMaxBytes = uint32(channel.Spec.ChannelConfig.Orderer.BatchSize.AbsoluteMaxBytes)
-				ordConfigtx.BatchSize.PreferredMaxBytes = uint32(channel.Spec.ChannelConfig.Orderer.BatchSize.PreferredMaxBytes)
+				ordConfigtx.BatchSize.MaxMessageCount = uint32(channel.Spec.ChannelConfig.Orderer.BatchSize.MaxMessageCount)     //nolint:gosec // batch config value fits uint32
+				ordConfigtx.BatchSize.AbsoluteMaxBytes = uint32(channel.Spec.ChannelConfig.Orderer.BatchSize.AbsoluteMaxBytes)   //nolint:gosec // batch config value fits uint32
+				ordConfigtx.BatchSize.PreferredMaxBytes = uint32(channel.Spec.ChannelConfig.Orderer.BatchSize.PreferredMaxBytes) //nolint:gosec // batch config value fits uint32
 			}
 		}
 	}

--- a/controllers/testutils/genesis.go
+++ b/controllers/testutils/genesis.go
@@ -370,7 +370,7 @@ func GetProfileConfig(
 			ordererPort := node.Port
 			consenters = append(consenters, &etcdraft.Consenter{
 				Host:          ordererHost,
-				Port:          uint32(ordererPort),
+				Port:          uint32(ordererPort), //nolint:gosec // port fits uint32
 				ClientTlsCert: []byte(clientCertFile.Name()),
 				ServerTlsCert: []byte(serverCertFile.Name()),
 			})
@@ -478,19 +478,19 @@ NodeOUs:
 			EtcdRaft: &etcdraft.ConfigMetadata{
 				Consenters: consenters,
 				Options: &etcdraft.Options{
-					SnapshotIntervalSize: uint32(config.SnapshotIntervalSize),
+					SnapshotIntervalSize: uint32(config.SnapshotIntervalSize), //nolint:gosec // config value fits uint32
 					TickInterval:         config.TickInterval,
-					ElectionTick:         uint32(config.ElectionTick),
-					HeartbeatTick:        uint32(config.HeartbeatTick),
-					MaxInflightBlocks:    uint32(config.MaxInflightBlocks),
+					ElectionTick:         uint32(config.ElectionTick),      //nolint:gosec // config value fits uint32
+					HeartbeatTick:        uint32(config.HeartbeatTick),     //nolint:gosec // config value fits uint32
+					MaxInflightBlocks:    uint32(config.MaxInflightBlocks), //nolint:gosec // config value fits uint32
 				},
 			},
 			Addresses:    ordererAddresses,
 			BatchTimeout: config.BatchTimeout,
 			BatchSize: genesisconfig.BatchSize{
-				MaxMessageCount:   uint32(config.MaxMessageCount),
-				AbsoluteMaxBytes:  uint32(config.AbsoluteMaxBytes),
-				PreferredMaxBytes: uint32(config.PreferredMaxBytes),
+				MaxMessageCount:   uint32(config.MaxMessageCount),   //nolint:gosec // config value fits uint32
+				AbsoluteMaxBytes:  uint32(config.AbsoluteMaxBytes),  //nolint:gosec // config value fits uint32
+				PreferredMaxBytes: uint32(config.PreferredMaxBytes), //nolint:gosec // config value fits uint32
 			},
 			Organizations: ordererOrganizations,
 			Policies: map[string]*genesisconfig.Policy{
@@ -603,7 +603,7 @@ func GetChannelProfileConfig(
 		ordererPort := node.Port
 		consenters = append(consenters, &etcdraft.Consenter{
 			Host:          ordererHost,
-			Port:          uint32(ordererPort),
+			Port:          uint32(ordererPort), //nolint:gosec // port fits uint32
 			ClientTlsCert: []byte(clientCertFile.Name()),
 			ServerTlsCert: []byte(serverCertFile.Name()),
 		})

--- a/kubectl-hlf/cmd/ca/enroll.go
+++ b/kubectl-hlf/cmd/ca/enroll.go
@@ -127,7 +127,7 @@ func (c *enrollCmd) run(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.fileOutput, userYaml, 0644)
+	err = ioutil.WriteFile(c.fileOutput, userYaml, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/chaincode/getlatest.go
+++ b/kubectl-hlf/cmd/chaincode/getlatest.go
@@ -69,7 +69,7 @@ func (c *getLatestInfoCmd) run(out io.Writer, stdErr io.Writer) error {
 	} else {
 		data = []byte(strconv.FormatInt(latestCC.Sequence, 10))
 	}
-	err = ioutil.WriteFile(c.outFile, data, 0777)
+	err = ioutil.WriteFile(c.outFile, data, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/chaincode/getnext.go
+++ b/kubectl-hlf/cmd/chaincode/getnext.go
@@ -165,7 +165,7 @@ func (c *getNextCmd) run(out io.Writer, stdErr io.Writer) error {
 			data = []byte(strconv.FormatInt(latestCC.Sequence, 10))
 		}
 	}
-	err = ioutil.WriteFile(c.outFile, data, 0777)
+	err = ioutil.WriteFile(c.outFile, data, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/channel/consenter/add.go
+++ b/kubectl-hlf/cmd/channel/consenter/add.go
@@ -103,7 +103,7 @@ func (c *addConsenterCmd) run() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.output, channelConfigBytes, 0755)
+	err = ioutil.WriteFile(c.output, channelConfigBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/channel/consenter/remove.go
+++ b/kubectl-hlf/cmd/channel/consenter/remove.go
@@ -97,7 +97,7 @@ func (c *delConsenterCmd) run() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.output, channelConfigBytes, 0755)
+	err = ioutil.WriteFile(c.output, channelConfigBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/channel/consenter/replace.go
+++ b/kubectl-hlf/cmd/channel/consenter/replace.go
@@ -110,7 +110,7 @@ func (c *replaceonsenterCmd) run() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.output, channelConfigBytes, 0755)
+	err = ioutil.WriteFile(c.output, channelConfigBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/channel/generate.go
+++ b/kubectl-hlf/cmd/channel/generate.go
@@ -246,9 +246,9 @@ func (c generateChannelCmd) run() error {
 		testutils.WithPeerOrgs(peerOrgs...),
 		testutils.WithConsenters(consenters...),
 		testutils.WithBatchSize(&orderer.BatchSize{
-			MaxMessageCount:   uint32(c.maxMessageCount),
-			AbsoluteMaxBytes:  uint32(c.absoluteMaxBytes),
-			PreferredMaxBytes: uint32(c.preferredMaxBytes),
+			MaxMessageCount:   uint32(c.maxMessageCount),   //nolint:gosec // config value fits uint32
+			AbsoluteMaxBytes:  uint32(c.absoluteMaxBytes),  //nolint:gosec // config value fits uint32
+			PreferredMaxBytes: uint32(c.preferredMaxBytes), //nolint:gosec // config value fits uint32
 		}),
 		testutils.WithBatchTimeout(time.Duration(c.batchTimeout)*time.Second),
 		testutils.WithConsensus(c.consensus),
@@ -260,7 +260,7 @@ func (c generateChannelCmd) run() error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(c.output, blockBytes, 0755)
+	err = os.WriteFile(c.output, blockBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/channel/ordorg/add.go
+++ b/kubectl-hlf/cmd/channel/ordorg/add.go
@@ -93,7 +93,7 @@ func (c *addOrgCmd) run(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.output, configEnvelopeBytes, 0755)
+	err = ioutil.WriteFile(c.output, configEnvelopeBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/channel/ordorg/remove.go
+++ b/kubectl-hlf/cmd/channel/ordorg/remove.go
@@ -65,7 +65,7 @@ func (c *removeOrgCmd) run(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.output, channelConfigBytes, 0755)
+	err = ioutil.WriteFile(c.output, channelConfigBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/channel/signupdate.go
+++ b/kubectl-hlf/cmd/channel/signupdate.go
@@ -123,7 +123,7 @@ func (c *signUpdateChannelCmd) run(out io.Writer) error {
 	}
 
 	if c.output != "" {
-		err = os.WriteFile(c.output, signatureBytes, 0644)
+		err = os.WriteFile(c.output, signatureBytes, 0600)
 		if err != nil {
 			return err
 		}

--- a/kubectl-hlf/cmd/fop/export/ca.go
+++ b/kubectl-hlf/cmd/fop/export/ca.go
@@ -51,7 +51,7 @@ func (c exportCACmd) run(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.outFile, caBytes, 0755)
+	err = ioutil.WriteFile(c.outFile, caBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/fop/export/orderer.go
+++ b/kubectl-hlf/cmd/fop/export/orderer.go
@@ -72,7 +72,7 @@ func (c exportOrdererCmd) run(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.outFile, ordererBytes, 0755)
+	err = ioutil.WriteFile(c.outFile, ordererBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/fop/export/org.go
+++ b/kubectl-hlf/cmd/fop/export/org.go
@@ -65,7 +65,7 @@ func (c exportOrgCmd) run(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.outFile, caBytes, 0755)
+	err = ioutil.WriteFile(c.outFile, caBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/fop/export/peer.go
+++ b/kubectl-hlf/cmd/fop/export/peer.go
@@ -54,7 +54,7 @@ func (c exportPeerCmd) run(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(c.outFile, peerBytes, 0755)
+	err = ioutil.WriteFile(c.outFile, peerBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/kubectl-hlf/cmd/networkconfig/export.go
+++ b/kubectl-hlf/cmd/networkconfig/export.go
@@ -74,7 +74,7 @@ func (d *networkConfigExportCmd) run(args []string) error {
 	}
 	networkConfigBytes := secret.Data["config.yaml"]
 	if d.output != "" {
-		err = ioutil.WriteFile(d.output, networkConfigBytes, 0777)
+		err = ioutil.WriteFile(d.output, networkConfigBytes, 0600)
 		if err != nil {
 			return err
 		}

--- a/kubectl-hlf/cmd/org/inspect.go
+++ b/kubectl-hlf/cmd/org/inspect.go
@@ -250,7 +250,7 @@ NodeOUs:
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile("configtx.yaml", buf.Bytes(), 0777)
+	err = ioutil.WriteFile("configtx.yaml", buf.Bytes(), 0600)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 	}()
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme:           scheme,
+		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress:    metricsAddr,
 			SecureServing:  true,


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds missing security fixes that should have been part of PR #301:

- **G115 nosec annotations**: Safe integer conversions (port numbers, replica counts, batch config values) that gosec flags but are not actual overflow risks
- **G306 file permissions**: Tightens `WriteFile` calls from `0777`/`0644` to `0600`
- **gofmt**: Fixes alignment in `main.go`

#### Which issue(s) this PR fixes:

Follow-up to #301 — these changes were applied locally but missed from the commit.

#### Special notes for your reviewer:

All changes are minimal: inline `#nosec` comments and permission constant changes. No logic changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation, usage docs, etc.:

```docs
NONE
```