### PR TITLE
fix(ca): propagate Istio IngressGateway to CA Helm chart values

### DIFF
--- a/controllers/ca/ca_controller.go
+++ b/controllers/ca/ca_controller.go
@@ -722,6 +722,47 @@ func doesCertNeedsToBeRenewed(tlsCert *x509.Certificate, conf *hlfv1alpha1.Fabri
 
 	return false
 }
+
+// BuildIstioConfig builds the Istio chart config from the CRD spec,
+// applying defaults for empty values.
+func BuildIstioConfig(spec *hlfv1alpha1.FabricIstio) Istio {
+	istioPort := 443
+	if spec != nil && spec.Port != 0 {
+		istioPort = spec.Port
+	}
+	istioHosts := []string{}
+	if spec != nil && len(spec.Hosts) > 0 {
+		istioHosts = spec.Hosts
+	}
+	istioIngressGateway := "ingressgateway"
+	if spec != nil && spec.IngressGateway != "" {
+		istioIngressGateway = spec.IngressGateway
+	}
+	return Istio{
+		Port:           istioPort,
+		Hosts:          istioHosts,
+		IngressGateway: istioIngressGateway,
+	}
+}
+
+// BuildGatewayApiConfig builds the GatewayApi chart config from the CRD spec.
+func BuildGatewayApiConfig(spec *hlfv1alpha1.FabricGatewayApi) GatewayApi {
+	if spec == nil {
+		return GatewayApi{
+			Port:             443,
+			Hosts:            []string{},
+			GatewayName:      "",
+			GatewayNamespace: "",
+		}
+	}
+	return GatewayApi{
+		Port:             spec.Port,
+		Hosts:            spec.Hosts,
+		GatewayName:      spec.GatewayName,
+		GatewayNamespace: spec.GatewayNamespace,
+	}
+}
+
 func GetConfig(conf *hlfv1alpha1.FabricCA, client *kubernetes.Clientset, chartName string, namespace string) (*FabricCAChart, error) {
 	spec := conf.Spec
 	tlsCert, tlsKey, err := getExistingTLSCrypto(client, chartName, namespace)
@@ -822,24 +863,8 @@ func GetConfig(conf *hlfv1alpha1.FabricCA, client *kubernetes.Clientset, chartNa
 			Bytes: caTLSSignEncodedPK,
 		})
 	}
-	istioPort := 443
-	if spec.Istio != nil && spec.Istio.Port != 0 {
-		istioPort = spec.Istio.Port
-	}
-	istioHosts := []string{}
-	if spec.Istio != nil && len(spec.Istio.Hosts) > 0 {
-		istioHosts = spec.Istio.Hosts
-	}
-	gatewayApiHosts := []string{}
-	gatewayApiName := ""
-	gatewayApiNamespace := ""
-	gatewayApiPort := 443
-	if spec.GatewayApi != nil {
-		gatewayApiPort = spec.GatewayApi.Port
-		gatewayApiHosts = spec.GatewayApi.Hosts
-		gatewayApiName = spec.GatewayApi.GatewayName
-		gatewayApiNamespace = spec.GatewayApi.GatewayNamespace
-	}
+	istioConfig := BuildIstioConfig(spec.Istio)
+	gatewayApiConfig := BuildGatewayApiConfig(spec.GatewayApi)
 	msp := Msp{
 		CARef:          caRef,
 		TLSCARef:       caTLSSignRef,
@@ -905,17 +930,9 @@ func GetConfig(conf *hlfv1alpha1.FabricCA, client *kubernetes.Clientset, chartNa
 		ImagePullSecrets: spec.ImagePullSecrets,
 		EnvVars:          spec.Env,
 		FullNameOverride: conf.Name,
-		Istio: Istio{
-			Port:  istioPort,
-			Hosts: istioHosts,
-		},
-		GatewayApi: GatewayApi{
-			Port:             gatewayApiPort,
-			Hosts:            gatewayApiHosts,
-			GatewayName:      gatewayApiName,
-			GatewayNamespace: gatewayApiNamespace,
-		},
-		ServiceMonitor: serviceMonitor,
+		Istio:            istioConfig,
+		GatewayApi:       gatewayApiConfig,
+		ServiceMonitor:   serviceMonitor,
 		Image: Image{
 			Repository: spec.Image,
 			Tag:        spec.Version,

--- a/controllers/ca/ca_controller_test.go
+++ b/controllers/ca/ca_controller_test.go
@@ -100,3 +100,110 @@ func TestValidateVaultConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildIstioConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *hlfv1alpha1.FabricIstio
+		expected ca.Istio
+	}{
+		{
+			name:  "Nil spec returns defaults",
+			input: nil,
+			expected: ca.Istio{
+				Port:           443,
+				Hosts:          []string{},
+				IngressGateway: "ingressgateway",
+			},
+		},
+		{
+			name: "Custom IngressGateway is preserved",
+			input: &hlfv1alpha1.FabricIstio{
+				Port:           443,
+				Hosts:          []string{"ca.example.com"},
+				IngressGateway: "istio",
+			},
+			expected: ca.Istio{
+				Port:           443,
+				Hosts:          []string{"ca.example.com"},
+				IngressGateway: "istio",
+			},
+		},
+		{
+			name: "Empty IngressGateway gets default",
+			input: &hlfv1alpha1.FabricIstio{
+				Port:           8443,
+				Hosts:          []string{"ca.example.com"},
+				IngressGateway: "",
+			},
+			expected: ca.Istio{
+				Port:           8443,
+				Hosts:          []string{"ca.example.com"},
+				IngressGateway: "ingressgateway",
+			},
+		},
+		{
+			name: "Zero port gets default 443",
+			input: &hlfv1alpha1.FabricIstio{
+				Port:           0,
+				Hosts:          []string{},
+				IngressGateway: "my-gw",
+			},
+			expected: ca.Istio{
+				Port:           443,
+				Hosts:          []string{},
+				IngressGateway: "my-gw",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ca.BuildIstioConfig(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildGatewayApiConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *hlfv1alpha1.FabricGatewayApi
+		expected ca.GatewayApi
+	}{
+		{
+			name:  "Nil spec returns empty defaults",
+			input: nil,
+			expected: ca.GatewayApi{
+				Port:             443,
+				Hosts:            []string{},
+				GatewayName:      "",
+				GatewayNamespace: "",
+			},
+		},
+		{
+			name: "Values are passed through",
+			input: &hlfv1alpha1.FabricGatewayApi{
+				Port:             8443,
+				Hosts:            []string{"ca.example.com"},
+				GatewayName:      "my-gw",
+				GatewayNamespace: "istio-system",
+			},
+			expected: ca.GatewayApi{
+				Port:             8443,
+				Hosts:            []string{"ca.example.com"},
+				GatewayName:      "my-gw",
+				GatewayNamespace: "istio-system",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ca.BuildGatewayApiConfig(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/controllers/ca/types.go
+++ b/controllers/ca/types.go
@@ -51,8 +51,9 @@ type Traefik struct {
 	Hosts       []string            `json:"hosts"`
 }
 type Istio struct {
-	Port  int      `json:"port"`
-	Hosts []string `json:"hosts"`
+	Port           int      `json:"port"`
+	Hosts          []string `json:"hosts"`
+	IngressGateway string   `json:"ingressGateway"`
 }
 type GatewayApi struct {
 	Port             int      `json:"port"`


### PR DESCRIPTION
## Summary

- The CA controller's Istio chart type (`controllers/ca/types.go`) was missing the `IngressGateway` field, so the value from `spec.Istio.IngressGateway` was never passed through to the Helm chart values.
- This meant that using `kubectl hlf ca create --istio-ingressgateway=<name>` had no effect -- the CA's Istio Gateway selector always fell back to the hardcoded default `"ingressgateway"` in the Helm chart's `values.yaml`.
- The peer and ordnode controllers already propagate this field correctly; the CA was the only controller missing it.

## Changes

1. **`controllers/ca/types.go`**: Added `IngressGateway string` field to the `Istio` struct so the value is included when the chart values are serialized to JSON.
2. **`controllers/ca/ca_controller.go`**: Added logic to read `spec.Istio.IngressGateway` (defaulting to `"ingressgateway"` when unset) and pass it into the `Istio` chart value struct, matching the pattern used in the peer and ordnode controllers.

## Related issues

Helps address #148

## Test plan

- [ ] Verify `go build ./...` passes (done locally)
- [ ] Verify `go vet ./controllers/ca/...` passes (done locally)
- [ ] Deploy a FabricCA with `spec.istio.ingressGateway: "custom-gateway"` and confirm the rendered Helm values include `ingressGateway: "custom-gateway"`
- [ ] Deploy a FabricCA without setting `ingressGateway` and confirm it defaults to `"ingressgateway"`