### PR TITLE
fix(ordnode): correct gateway API namespace assignments in ordnode controller

### DIFF
--- a/controllers/ordnode/ordnode_controller.go
+++ b/controllers/ordnode/ordnode_controller.go
@@ -1070,6 +1070,33 @@ func getCertBytesFromCATLS(client *kubernetes.Clientset, caTls *hlfv1alpha1.Catl
 	}
 	return signCertBytes, nil
 }
+// BuildGatewayApiConfig builds the GatewayApi chart config from the CRD spec,
+// applying defaults for empty gateway name and namespace.
+func BuildGatewayApiConfig(spec *hlfv1alpha1.FabricGatewayApi) GatewayApi {
+	if spec == nil {
+		return GatewayApi{
+			Port:             443,
+			Hosts:            []string{},
+			GatewayName:      "",
+			GatewayNamespace: "",
+		}
+	}
+	gatewayApiName := spec.GatewayName
+	gatewayApiNamespace := spec.GatewayNamespace
+	if gatewayApiName == "" {
+		gatewayApiName = "hlf-gateway"
+	}
+	if gatewayApiNamespace == "" {
+		gatewayApiNamespace = "default"
+	}
+	return GatewayApi{
+		Port:             spec.Port,
+		Hosts:            spec.Hosts,
+		GatewayName:      gatewayApiName,
+		GatewayNamespace: gatewayApiNamespace,
+	}
+}
+
 func getConfig(
 	conf *hlfv1alpha1.FabricOrdererNode,
 	client *kubernetes.Clientset,
@@ -1281,30 +1308,7 @@ func getConfig(
 			IngressGateway: "",
 		}
 	}
-	var gatewayApi GatewayApi
-	if spec.GatewayApi != nil {
-		gatewayApiName := spec.GatewayApi.GatewayName
-		gatewayApiNamespace := spec.GatewayApi.GatewayNamespace
-		if gatewayApiName == "" {
-			gatewayApiName = "hlf-gateway"
-		}
-		if gatewayApiNamespace == "" {
-			gatewayApiName = "default"
-		}
-		gatewayApi = GatewayApi{
-			Port:             spec.GatewayApi.Port,
-			Hosts:            spec.GatewayApi.Hosts,
-			GatewayName:      gatewayApiName,
-			GatewayNamespace: gatewayApiNamespace,
-		}
-	} else {
-		gatewayApi = GatewayApi{
-			Port:             443,
-			Hosts:            []string{},
-			GatewayName:      "",
-			GatewayNamespace: "",
-		}
-	}
+	gatewayApi := BuildGatewayApiConfig(spec.GatewayApi)
 
 	traefik := Traefik{}
 	if spec.Traefik != nil {
@@ -1360,30 +1364,7 @@ func getConfig(
 			IngressGateway: "",
 		}
 	}
-	var adminGatewayApi GatewayApi
-	if spec.AdminGatewayApi != nil {
-		gatewayApiName := spec.AdminGatewayApi.GatewayName
-		gatewayApiNamespace := spec.GatewayApi.GatewayNamespace
-		if gatewayApiName == "" {
-			gatewayApiName = "hlf-gateway"
-		}
-		if gatewayApiNamespace == "" {
-			gatewayApiName = "default"
-		}
-		adminGatewayApi = GatewayApi{
-			Port:             spec.AdminGatewayApi.Port,
-			Hosts:            spec.AdminGatewayApi.Hosts,
-			GatewayName:      gatewayApiName,
-			GatewayNamespace: gatewayApiNamespace,
-		}
-	} else {
-		adminGatewayApi = GatewayApi{
-			Port:             443,
-			Hosts:            []string{},
-			GatewayName:      "",
-			GatewayNamespace: "",
-		}
-	}
+	adminGatewayApi := BuildGatewayApiConfig(spec.AdminGatewayApi)
 	var monitor ServiceMonitor
 	if spec.ServiceMonitor != nil && spec.ServiceMonitor.Enabled {
 		monitor = ServiceMonitor{

--- a/controllers/ordnode/ordnode_controller_test.go
+++ b/controllers/ordnode/ordnode_controller_test.go
@@ -241,3 +241,90 @@ func TestValidateOrdererNode(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildGatewayApiConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *hlfv1alpha1.FabricGatewayApi
+		expected ordnode.GatewayApi
+	}{
+		{
+			name:  "Nil spec returns empty defaults",
+			input: nil,
+			expected: ordnode.GatewayApi{
+				Port:             443,
+				Hosts:            []string{},
+				GatewayName:      "",
+				GatewayNamespace: "",
+			},
+		},
+		{
+			name: "Empty name and namespace get defaults",
+			input: &hlfv1alpha1.FabricGatewayApi{
+				Port:             443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "",
+				GatewayNamespace: "",
+			},
+			expected: ordnode.GatewayApi{
+				Port:             443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "hlf-gateway",
+				GatewayNamespace: "default",
+			},
+		},
+		{
+			name: "Custom values are preserved",
+			input: &hlfv1alpha1.FabricGatewayApi{
+				Port:             8443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "my-gateway",
+				GatewayNamespace: "istio-system",
+			},
+			expected: ordnode.GatewayApi{
+				Port:             8443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "my-gateway",
+				GatewayNamespace: "istio-system",
+			},
+		},
+		{
+			name: "Empty namespace gets default while name is preserved",
+			input: &hlfv1alpha1.FabricGatewayApi{
+				Port:             443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "custom-gw",
+				GatewayNamespace: "",
+			},
+			expected: ordnode.GatewayApi{
+				Port:             443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "custom-gw",
+				GatewayNamespace: "default",
+			},
+		},
+		{
+			name: "Empty name gets default while namespace is preserved",
+			input: &hlfv1alpha1.FabricGatewayApi{
+				Port:             443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "",
+				GatewayNamespace: "my-ns",
+			},
+			expected: ordnode.GatewayApi{
+				Port:             443,
+				Hosts:            []string{"orderer.example.com"},
+				GatewayName:      "hlf-gateway",
+				GatewayNamespace: "my-ns",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ordnode.BuildGatewayApiConfig(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes three bugs in the ordnode controller's Gateway API namespace assignment logic that caused Gateway API routing to break for orderer nodes when the namespace was not explicitly set.

### Bug 1: Regular GatewayApi default namespace typo (line 1292)
When `gatewayApiNamespace` was empty, the fallback incorrectly assigned to `gatewayApiName` instead of `gatewayApiNamespace`:
```go
// Before (broken)
if gatewayApiNamespace == "" {
    gatewayApiName = "default"
}

// After (fixed)
if gatewayApiNamespace == "" {
    gatewayApiNamespace = "default"
}
```

### Bug 2: AdminGatewayApi reading namespace from wrong spec (line 1366)
The admin gateway API was reading the namespace from `spec.GatewayApi` instead of `spec.AdminGatewayApi`:
```go
// Before (broken)
gatewayApiNamespace := spec.GatewayApi.GatewayNamespace

// After (fixed)
gatewayApiNamespace := spec.AdminGatewayApi.GatewayNamespace
```

### Bug 3: AdminGatewayApi default namespace typo (line 1371)
Same name/namespace typo as Bug 1, but in the admin gateway block:
```go
// Before (broken)
if gatewayApiNamespace == "" {
    gatewayApiName = "default"
}

// After (fixed)
if gatewayApiNamespace == "" {
    gatewayApiNamespace = "default"
}
```

## Related Issues

Helps address #236 and #291.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./controllers/ordnode/...` passes
- [ ] Deploy an orderer node with Gateway API enabled and namespace left empty; verify it defaults to `"default"` correctly
- [ ] Deploy an orderer node with AdminGatewayApi configured; verify it reads from the correct spec and defaults correctly