### PR TITLE
fix: correct gateway namespace assignments and CA Istio ingress propagation

### DIFF
--- a/charts/hlf-ordnode/templates/tlsroute-admin.yaml
+++ b/charts/hlf-ordnode/templates/tlsroute-admin.yaml
@@ -7,7 +7,7 @@ spec:
   parentRefs:
     - name: {{.Values.adminGatewayApi.gatewayName}}
       sectionName: tcp
-      namespace: {{.Values.gatewayApi.gatewayNamespace}}
+      namespace: {{.Values.adminGatewayApi.gatewayNamespace}}
   hostnames:
   {{- range .Values.adminGatewayApi.hosts }}
       - {{ . }}

--- a/controllers/ca/ca_controller.go
+++ b/controllers/ca/ca_controller.go
@@ -830,6 +830,10 @@ func GetConfig(conf *hlfv1alpha1.FabricCA, client *kubernetes.Clientset, chartNa
 	if spec.Istio != nil && len(spec.Istio.Hosts) > 0 {
 		istioHosts = spec.Istio.Hosts
 	}
+	istioIngressGateway := "ingressgateway"
+	if spec.Istio != nil && spec.Istio.IngressGateway != "" {
+		istioIngressGateway = spec.Istio.IngressGateway
+	}
 	gatewayApiHosts := []string{}
 	gatewayApiName := ""
 	gatewayApiNamespace := ""
@@ -906,8 +910,9 @@ func GetConfig(conf *hlfv1alpha1.FabricCA, client *kubernetes.Clientset, chartNa
 		EnvVars:          spec.Env,
 		FullNameOverride: conf.Name,
 		Istio: Istio{
-			Port:  istioPort,
-			Hosts: istioHosts,
+			Port:           istioPort,
+			Hosts:          istioHosts,
+			IngressGateway: istioIngressGateway,
 		},
 		GatewayApi: GatewayApi{
 			Port:             gatewayApiPort,

--- a/controllers/ca/types.go
+++ b/controllers/ca/types.go
@@ -51,8 +51,9 @@ type Traefik struct {
 	Hosts       []string            `json:"hosts"`
 }
 type Istio struct {
-	Port  int      `json:"port"`
-	Hosts []string `json:"hosts"`
+	Port           int      `json:"port"`
+	Hosts          []string `json:"hosts"`
+	IngressGateway string   `json:"ingressGateway"`
 }
 type GatewayApi struct {
 	Port             int      `json:"port"`

--- a/controllers/ordnode/ordnode_controller.go
+++ b/controllers/ordnode/ordnode_controller.go
@@ -1289,7 +1289,7 @@ func getConfig(
 			gatewayApiName = "hlf-gateway"
 		}
 		if gatewayApiNamespace == "" {
-			gatewayApiName = "default"
+			gatewayApiNamespace = "default"
 		}
 		gatewayApi = GatewayApi{
 			Port:             spec.GatewayApi.Port,
@@ -1363,12 +1363,12 @@ func getConfig(
 	var adminGatewayApi GatewayApi
 	if spec.AdminGatewayApi != nil {
 		gatewayApiName := spec.AdminGatewayApi.GatewayName
-		gatewayApiNamespace := spec.GatewayApi.GatewayNamespace
+		gatewayApiNamespace := spec.AdminGatewayApi.GatewayNamespace
 		if gatewayApiName == "" {
 			gatewayApiName = "hlf-gateway"
 		}
 		if gatewayApiNamespace == "" {
-			gatewayApiName = "default"
+			gatewayApiNamespace = "default"
 		}
 		adminGatewayApi = GatewayApi{
 			Port:             spec.AdminGatewayApi.Port,

--- a/controllers/peer/peer_controller.go
+++ b/controllers/peer/peer_controller.go
@@ -1686,7 +1686,7 @@ func GetConfig(
 			gatewayApiName = "hlf-gateway"
 		}
 		if gatewayApiNamespace == "" {
-			gatewayApiName = "default"
+			gatewayApiNamespace = "default"
 		}
 		gatewayApi = GatewayApi{
 			Port:             spec.GatewayApi.Port,


### PR DESCRIPTION
## Summary

- **Fix gateway namespace fallback typo** in ordnode, peer, and admin gateway controllers: the `"default"` fallback for an empty namespace was assigned to `gatewayApiName` instead of `gatewayApiNamespace`, silently corrupting the gateway name while leaving the namespace empty
- **Fix admin gateway namespace source** in ordnode controller: `AdminGatewayApi` was reading the namespace from `spec.GatewayApi.GatewayNamespace` instead of `spec.AdminGatewayApi.GatewayNamespace`
- **Fix admin TLSRoute Helm template** in `hlf-ordnode`: the template referenced `.Values.gatewayApi.gatewayNamespace` instead of `.Values.adminGatewayApi.gatewayNamespace`
- **Propagate Istio IngressGateway to CA chart**: the `IngressGateway` field from the CA spec was never passed to Helm values, so CAs always used the hardcoded `"ingressgateway"` default regardless of user configuration

## Affected components

| Component | File | Bug |
|-----------|------|-----|
| Orderer node | `controllers/ordnode/ordnode_controller.go` | namespace→name typo (x2), wrong source field for admin namespace |
| Peer | `controllers/peer/peer_controller.go` | namespace→name typo |
| Orderer chart | `charts/hlf-ordnode/templates/tlsroute-admin.yaml` | wrong values path |
| CA | `controllers/ca/ca_controller.go`, `controllers/ca/types.go` | missing IngressGateway propagation |

## Test plan

- [ ] Deploy orderer node with custom `GatewayApi.GatewayNamespace` — verify namespace is set correctly (not empty)
- [ ] Deploy orderer node with custom `AdminGatewayApi` — verify admin TLSRoute uses admin namespace, not the regular gateway namespace
- [ ] Deploy peer with custom `GatewayApi.GatewayNamespace` — verify namespace is set correctly
- [ ] Deploy CA with custom `Istio.IngressGateway` — verify the Helm release uses the configured gateway, not `"ingressgateway"`