### PR TITLE
fix: make chaincode package ID deterministic (#323)

### DIFF
--- a/controllers/chaincode/install/chaincode_install_controller.go
+++ b/controllers/chaincode/install/chaincode_install_controller.go
@@ -166,6 +166,20 @@ func addFileToTar(tw *tar.Writer, filename string) error {
 	}
 
 	header.Name = filepath.Base(filename)
+	// Canonicalize everything that comes from the filesystem rather than the
+	// package contents. The package ID is label + SHA256 over the raw archive
+	// bytes, headers included; the temp files are rewritten on every reconcile,
+	// so filesystem-derived header fields (most visibly ModTime, with its
+	// 1-second resolution) made the package ID non-deterministic for an
+	// identical spec. See #323.
+	header.ModTime = time.Unix(0, 0)
+	header.AccessTime = time.Time{}
+	header.ChangeTime = time.Time{}
+	header.Uid = 0
+	header.Gid = 0
+	header.Uname = ""
+	header.Gname = ""
+	header.Mode = 0o644
 
 	if err := tw.WriteHeader(header); err != nil {
 		return err

--- a/controllers/chaincode/install/determinism_test.go
+++ b/controllers/chaincode/install/determinism_test.go
@@ -1,0 +1,45 @@
+package install
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-sdk-go/pkg/fab/ccpackager/lifecycle"
+	"os"
+)
+
+// The package ID must be a pure function of the spec: two builds of the same
+// options, separated by more than tar's 1-second mtime resolution, must hash
+// identically. See #323.
+func TestGenerateChaincodePackageDeterministic(t *testing.T) {
+	opts := ChaincodePackageOptions{
+		ChaincodeName:  "probe",
+		ChaincodeLabel: "probe",
+		Address:        "probe-cc.example:9999",
+	}
+	p1, err := generateChaincodePackage(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(p1)
+	time.Sleep(1100 * time.Millisecond)
+	p2, err := generateChaincodePackage(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(p2)
+
+	b1, err := os.ReadFile(p1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(p2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id1 := lifecycle.ComputePackageID(opts.ChaincodeLabel, b1)
+	id2 := lifecycle.ComputePackageID(opts.ChaincodeLabel, b2)
+	if id1 != id2 {
+		t.Fatalf("package ID not deterministic:\n  %s\n  %s", id1, id2)
+	}
+}


### PR DESCRIPTION
Fixes the non-deterministic package ID reported in #323 (analysis in the issue comments).

`addFileToTar` builds tar headers with `tar.FileInfoHeader`, which copies each temp file's modification time into the archive. `lifecycle.ComputePackageID` is `label + SHA256(raw tar.gz bytes)` — headers included — and `generateChaincodePackage` rewrites the temp files on every reconcile, so any two builds crossing a 1-second boundary produce different package IDs for an identical spec. This is also what makes the controller unable to recognise an already-installed package and reinstall indefinitely after peer restarts.

This PR canonicalizes the filesystem-derived header fields (ModTime, Access/ChangeTime, uid/gid, uname/gname, mode), making the package ID a pure function of the `chaincodePackage` spec.

**Test:** `TestGenerateChaincodePackageDeterministic` builds the package twice 1.1 s apart and asserts the IDs match. It fails against current `main` and passes with this change. Verified locally with `go build ./controllers/chaincode/install/` and `go test ./controllers/chaincode/install/ -run TestGenerateChaincodePackageDeterministic`.